### PR TITLE
Port-Group speed updates and Interface valid-speeds issue. #67

### DIFF
--- a/orca_nw_lib/portgroup.py
+++ b/orca_nw_lib/portgroup.py
@@ -81,7 +81,7 @@ def get_port_group_members(device_ip: str, group_id):
             op_dict.append(mem_if.__properties__)
     return op_dict
 
-def get_port_group_of_interface(device_ip: str, if_name:str):
+def get_port_group_of_interface(device_ip: str, group_id:str):
     """
     Retrieves the members of a port group based on the device IP and group ID.
 
@@ -151,3 +151,7 @@ def set_port_group_speed(device_ip: str, port_group_id: str, speed: Speed):
             f"Port Group {port_group_id} speed change failed on device {device_ip}, Reason: {e}"
         )
         raise
+    finally:
+        from orca_nw_lib.interface import discover_interfaces
+        for mem_if in get_port_group_members(device_ip, port_group_id):
+            discover_interfaces(device_ip, mem_if.get("name"))

--- a/orca_nw_lib/portgroup.py
+++ b/orca_nw_lib/portgroup.py
@@ -10,7 +10,7 @@ from orca_nw_lib.portgroup_db import (
     get_port_group_member_from_db,
     get_port_group_member_names_from_db,
     insert_device_port_groups_in_db,
-    get_port_group_from_db,
+    get_port_group_from_db, get_port_group_of_if_from_db,
 )
 from orca_nw_lib.utils import get_logging
 
@@ -81,23 +81,20 @@ def get_port_group_members(device_ip: str, group_id):
             op_dict.append(mem_if.__properties__)
     return op_dict
 
-def get_port_group_of_interface(device_ip: str, group_id:str):
+def get_port_group_of_interface(device_ip: str, if_name:str):
     """
-    Retrieves the members of a port group based on the device IP and group ID.
+    Retrieves the port group of an interface based on the device IP and interface name.
 
     Args:
         device_ip (str): The IP address of the device.
-        group_id: The ID of the port group.
+        if_name: The name of the interface.
 
     Returns:
-        list: A list of dictionaries representing the properties of each member interface.
+        dict: A dictionary representing the properties of the port group of the interface.
     """
-    op_dict = []
-    mem_intfcs = get_port_group_member_from_db(device_ip, group_id)
-    if mem_intfcs:
-        for mem_if in mem_intfcs or []:
-            op_dict.append(mem_if.__properties__)
-    return op_dict
+    port_group = get_port_group_of_if_from_db(device_ip, if_name)
+    return port_group.__properties__
+
 
 def get_port_groups(device_ip: str, port_group_id=None):
     if port_group_id:

--- a/orca_nw_lib/portgroup_db.py
+++ b/orca_nw_lib/portgroup_db.py
@@ -122,13 +122,23 @@ def get_port_group_member_names_from_db(device_ip: str, group_id) -> List[str]:
     return [intf.name for intf in intfcs or []]
 
 
-def get_port_group_of_if_from_db(device_ip: str, inertface_name: str) -> PortGroup:
+def get_port_group_of_if_from_db(device_ip: str, interface_name: str) -> PortGroup:
+    """
+    Retrieve the port group object of an interface from the database.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        interface_name: The name of the interface.
+
+    Returns:
+        PortGroup: The port group object of the interface.
+    """
 
     ## TODO: Following query certainly has scope of performance enhancement.
     ## retrieve the port group object via relation.
     for pg in get_port_group_from_db(device_ip) or []:
         for intf in pg.memberInterfaces.all():
-            if intf.name == inertface_name:
+            if intf.name == interface_name:
                 return pg
     return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.15"
+version = "1.3.16"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.16"
+version = "1.3.17"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"


### PR DESCRIPTION
Fixes #67 

issue: 

If port group speed is set to 25G , all interface in the port-group are updated to have the speed 25G, but the valid speeds and adv-speed set is still 1G and 10G which is not correct.

- The correct behaviour would be if port-group speed is updated, after receving the port-group update via gNMI subscription make an additional gnmi get to update the valid_speeds field for interface at sonic-port:sonic-port/PORT/PORT_LIST={interface_name}.

- Write test case for above.


Fixes: 
- Added interface discovery on speed update.
- Added test cases to validate. valid speeds update.