### PR TITLE
 Advance config options for PortChannels. #52

### DIFF
--- a/orca_nw_lib/port_chnl.py
+++ b/orca_nw_lib/port_chnl.py
@@ -23,7 +23,7 @@ from .port_chnl_gnmi import (
     add_port_chnl_valn_members_on_device,
     get_port_channel_ip_details_from_device,
 )
-from .utils import get_logging
+from .utils import get_logging, format_and_get_trunk_vlans
 
 _logger = get_logging().getLogger(__name__)
 
@@ -59,7 +59,7 @@ def _create_port_chnl_graph_object(device_ip: str) -> Dict[PortChannel, List[str
                 if lag.get("lagname") == port_chnl.get("name"):
                     port_chnl_item = port_chnl
                     if tagged_vlans := port_chnl.get("tagged_vlans"):
-                        port_chnl_vlan_member["trunk_vlans"] = [int(i) for i in tagged_vlans]
+                        port_chnl_vlan_member["trunk_vlans"] = format_and_get_trunk_vlans(tagged_vlans)
                     if access_vlan := port_chnl.get("access_vlan"):
                         port_chnl_vlan_member["access_vlan"] = int(access_vlan)
             ip_details = get_port_channel_ip_details_from_device(device_ip, lag.get("lagname")).get(

--- a/orca_nw_lib/port_chnl_gnmi.py
+++ b/orca_nw_lib/port_chnl_gnmi.py
@@ -7,7 +7,7 @@ from orca_nw_lib.gnmi_util import (
     send_gnmi_set,
 )
 from orca_nw_lib.portgroup_gnmi import get_port_chnl_mem_base_path
-from orca_nw_lib.utils import get_logging, validate_and_get_ip_prefix
+from orca_nw_lib.utils import get_logging, validate_and_get_ip_prefix, format_and_get_trunk_vlans
 from .gnmi_pb2 import Path, PathElem
 from .gnmi_util import (
     create_gnmi_update,
@@ -456,14 +456,14 @@ def get_port_channel_vlan_memebers_path(port_channel_name: str):
 
 
 def create_port_channel_vlan_gnmi_update_req(
-        port_channel_name: str, trunk_vlans: list[int] = None, access_vlan: int = None
+        port_channel_name: str, trunk_vlans: list = None, access_vlan: int = None
 ):
     """
     Creates a GNMI update request for configuring VLAN members on a port channel.
 
     Parameters:
         port_channel_name (str): The name of the port channel.
-        trunk_vlans (list[int]): The list of VLAN IDs to be configured as trunk VLANs.
+        trunk_vlans (list): The list of VLAN IDs to be configured as trunk VLANs.
         access_vlan (int): The VLAN ID to be configured as access VLAN.
 
     Returns:
@@ -471,7 +471,8 @@ def create_port_channel_vlan_gnmi_update_req(
     """
     vlan_config_members = {}
     if trunk_vlans is not None:
-        vlan_config_members["trunk-vlans"] = trunk_vlans
+        # checking input format change into list of ids
+        vlan_config_members["trunk-vlans"] = format_and_get_trunk_vlans(trunk_vlans)
     if access_vlan is not None:
         vlan_config_members["access-vlan"] = access_vlan
     return create_gnmi_update(

--- a/orca_nw_lib/port_chnl_gnmi.py
+++ b/orca_nw_lib/port_chnl_gnmi.py
@@ -470,10 +470,10 @@ def create_port_channel_vlan_gnmi_update_req(
         The GNMI update request for configuring VLAN members on the specified port channel.
     """
     vlan_config_members = {}
-    if trunk_vlans is not None:
+    if trunk_vlans:
         # checking input format change into list of ids
         vlan_config_members["trunk-vlans"] = format_and_get_trunk_vlans(trunk_vlans)
-    if access_vlan is not None:
+    if access_vlan:  # checking if access vlan is empty
         vlan_config_members["access-vlan"] = access_vlan
     return create_gnmi_update(
         get_port_channel_vlan_memebers_path(port_channel_name=port_channel_name),

--- a/orca_nw_lib/utils.py
+++ b/orca_nw_lib/utils.py
@@ -179,7 +179,7 @@ def format_and_get_trunk_vlans(trunk_vlans: list):
     result = []
     for i in trunk_vlans:
         if isinstance(i, int):
-            result.append(int(i))
+            result.append(i)
         elif "-" in i:
             result.extend(
                 range(int(i.split("-")[0]), int(i.split("-")[1]) + 1)

--- a/orca_nw_lib/utils.py
+++ b/orca_nw_lib/utils.py
@@ -163,3 +163,29 @@ def validate_and_get_ip_prefix(network_address: str):
     except ValueError:
         _logger.error(f"Invalid network address: {network_address}")
         return None, None, None
+
+
+def format_and_get_trunk_vlans(trunk_vlans: list):
+    """
+    Formats and returns the list of trunk VLANs.
+
+    Args:
+        trunk_vlans (list): The list of trunk VLANs to format.
+
+    Returns:
+        list: The formatted list of trunk VLANs.
+    """
+
+    result = []
+    for i in trunk_vlans:
+        if isinstance(i, int):
+            result.append(int(i))
+        elif "-" in i:
+            result.extend(
+                range(int(i.split("-")[0]), int(i.split("-")[1]) + 1)
+            )
+        elif ".." in i:
+            result.extend(range(int(i.split("..")[0]), int(i.split("..")[1]) + 1))
+        else:
+            result.append(int(i))
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.16"
+version = "1.3.17"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.17"
+version = "1.3.18"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"


### PR DESCRIPTION
Issues: 

- the backednd will prompt the error i.e, - Couldn't discover Port Channel on device 10.10.229.58, Reason: invalid literal for int() with base 10: '2-4'
- sometimes the response is just the trunk vlans only

Fixes:

- resolved issue while adding to db using function - format_and_get_trunk_vlans in utils.py 
- added test cases test_port_channel_vlan_members_in_series.
- fixes typo issue for acces_vlan.