### PR TITLE
Mclag domain  additional configuration. - lib - #63

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,25 @@
         "*.py"
     ],
     "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": true
+    "python.testing.unittestEnabled": true,
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#00b300",
+        "activityBar.background": "#00b300",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#dfdfff",
+        "activityBarBadge.foreground": "#15202b",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#00b300",
+        "statusBar.background": "#008000",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#00b300",
+        "statusBarItem.remoteBackground": "#008000",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#008000",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#00800099",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.remoteColor": "green"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,25 +7,5 @@
         "*.py"
     ],
     "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": true,
-    "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#00b300",
-        "activityBar.background": "#00b300",
-        "activityBar.foreground": "#e7e7e7",
-        "activityBar.inactiveForeground": "#e7e7e799",
-        "activityBarBadge.background": "#dfdfff",
-        "activityBarBadge.foreground": "#15202b",
-        "commandCenter.border": "#e7e7e799",
-        "sash.hoverBorder": "#00b300",
-        "statusBar.background": "#008000",
-        "statusBar.foreground": "#e7e7e7",
-        "statusBarItem.hoverBackground": "#00b300",
-        "statusBarItem.remoteBackground": "#008000",
-        "statusBarItem.remoteForeground": "#e7e7e7",
-        "titleBar.activeBackground": "#008000",
-        "titleBar.activeForeground": "#e7e7e7",
-        "titleBar.inactiveBackground": "#00800099",
-        "titleBar.inactiveForeground": "#e7e7e799"
-    },
-    "peacock.remoteColor": "green"
+    "python.testing.unittestEnabled": true
 }

--- a/orca_nw_lib/mclag.py
+++ b/orca_nw_lib/mclag.py
@@ -55,7 +55,9 @@ def _create_mclag_graph_objects(device_ip: str) -> dict:
             device_ip=device_ip, domain_id=domain_id
         )
         fast_convergence = None
-        for mclag_item in mclag_device_details.get("sonic-mclag:MCLAG_DOMAIN_LIST") or []:
+        for mclag_item in (
+            mclag_device_details.get("sonic-mclag:MCLAG_DOMAIN_LIST") or []
+        ):
             if mclag_item.get("domain_id") == domain_id:
                 fast_convergence = mclag_item.get("fast_convergence")
         mclag_obj = MCLAG(
@@ -71,7 +73,7 @@ def _create_mclag_graph_objects(device_ip: str) -> dict:
             role=mclag_domain.get("state").get("role"),
             system_mac=mclag_domain.get("state").get("system-mac"),
             session_vrf=mclag_domain.get("config").get("session-vrf"),
-            fast_convergence=fast_convergence
+            fast_convergence=fast_convergence,
         )
         intfc_list = [
             mclag_intfc["name"]
@@ -133,9 +135,7 @@ def discover_mclag(device_ip: str = None):
                 device, _create_mclag_graph_objects(device.mgt_ip)
             )
         except Exception as e:
-            _logger.error(
-                f"MCLAG Discovery Failed on device {device_ip}, Reason: {e}"
-            )
+            _logger.error(f"MCLAG Discovery Failed on device {device_ip}, Reason: {e}")
             raise
     create_mclag_peer_link_rel_in_db()
 
@@ -192,7 +192,7 @@ def get_mclags(
 
 
 def config_mclag(
-    device_ip: int = None,
+    device_ip: int,
     domain_id: int = None,
     source_addr: str = None,
     peer_addr: str = None,
@@ -202,7 +202,7 @@ def config_mclag(
     session_timeout: int = 30,
     delay_restore: int = 300,
     session_vrf: str = None,
-    fast_convergence: MclagFastConvergence = None
+    fast_convergence: MclagFastConvergence = None,
 ):
     """
     Configures MCLAG on the device.
@@ -236,7 +236,7 @@ def config_mclag(
             session_timeout,
             delay_restore,
             session_vrf,
-            fast_convergence
+            fast_convergence,
         )
 
     except Exception as e:
@@ -244,8 +244,8 @@ def config_mclag(
             f" MCLAG configuration failed on device_ip : {device_ip}, Reason: {e}"
         )
         raise
-    finally: 
-            discover_mclag(device_ip)
+    finally:
+        discover_mclag(device_ip)
 
 
 def del_mclag(device_ip: str):
@@ -261,12 +261,10 @@ def del_mclag(device_ip: str):
     try:
         del_mclag_from_device(device_ip)
     except Exception as e:
-        _logger.error(
-            f" MCLAG deletion failed on device_ip : {device_ip}, Reason: {e}"
-        )
+        _logger.error(f" MCLAG deletion failed on device_ip : {device_ip}, Reason: {e}")
         raise
-    finally: 
-            discover_mclag(device_ip)
+    finally:
+        discover_mclag(device_ip)
 
 
 def get_mclag_gw_mac(
@@ -416,8 +414,8 @@ def config_mclag_mem_portchnl(
             f"MCLAG member {port_chnl_name} configuration failed on mclag_domain_id : {mclag_domain_id} and device_ip : {device_ip}, Reason: {e} "
         )
         raise
-    finally: 
-            discover_mclag(device_ip)
+    finally:
+        discover_mclag(device_ip)
 
 
 def del_mclag_member(device_ip: str):
@@ -437,8 +435,8 @@ def del_mclag_member(device_ip: str):
             f"MCLAG member deletion failed on device_ip : {device_ip}, Reason: {e}"
         )
         raise
-    finally: 
-            discover_mclag(device_ip)
+    finally:
+        discover_mclag(device_ip)
 
 
 def remove_mclag_domain_fast_convergence(device_ip: str, domain_id: int):
@@ -459,8 +457,8 @@ def remove_mclag_domain_fast_convergence(device_ip: str, domain_id: int):
             f"MCLAG domain fast convergence deletion failed on domain_id : {domain_id} and device_ip : {device_ip}, Reason: {e} "
         )
         raise
-    finally: 
-            discover_mclag(device_ip)
+    finally:
+        discover_mclag(device_ip)
 
 
 def add_mclag_domain_fast_convergence(device_ip: str, domain_id: int):
@@ -481,5 +479,5 @@ def add_mclag_domain_fast_convergence(device_ip: str, domain_id: int):
             f"MCLAG domain fast convergence deletion failed on domain_id : {domain_id} and device_ip : {device_ip}, Reason: {e} "
         )
         raise
-    finally: 
-            discover_mclag(device_ip)
+    finally:
+        discover_mclag(device_ip)

--- a/orca_nw_lib/mclag.py
+++ b/orca_nw_lib/mclag.py
@@ -192,15 +192,15 @@ def get_mclags(
 
 
 def config_mclag(
-    device_ip: str,
-    domain_id: int,
-    source_addr: str,
-    peer_addr: str,
-    peer_link: str,
-    mclag_sys_mac: str,
-    keepalive_int: int = None,
-    session_timeout: int = None,
-    delay_restore: int = None,
+    device_ip: int = None,
+    domain_id: int = None,
+    source_addr: str = None,
+    peer_addr: str = None,
+    peer_link: str = None,
+    mclag_sys_mac: str = None,
+    keepalive_int: int = 1,
+    session_timeout: int = 30,
+    delay_restore: int = 300,
     session_vrf: str = None,
     fast_convergence: MclagFastConvergence = None
 ):
@@ -244,8 +244,8 @@ def config_mclag(
             f" MCLAG configuration failed on device_ip : {device_ip}, Reason: {e}"
         )
         raise
-    finally:
-        discover_mclag(device_ip)
+    finally: 
+            discover_mclag(device_ip)
 
 
 def del_mclag(device_ip: str):
@@ -265,8 +265,8 @@ def del_mclag(device_ip: str):
             f" MCLAG deletion failed on device_ip : {device_ip}, Reason: {e}"
         )
         raise
-    finally:
-        discover_mclag(device_ip)
+    finally: 
+            discover_mclag(device_ip)
 
 
 def get_mclag_gw_mac(
@@ -416,8 +416,8 @@ def config_mclag_mem_portchnl(
             f"MCLAG member {port_chnl_name} configuration failed on mclag_domain_id : {mclag_domain_id} and device_ip : {device_ip}, Reason: {e} "
         )
         raise
-    finally:
-        discover_mclag(device_ip)
+    finally: 
+            discover_mclag(device_ip)
 
 
 def del_mclag_member(device_ip: str):
@@ -437,8 +437,8 @@ def del_mclag_member(device_ip: str):
             f"MCLAG member deletion failed on device_ip : {device_ip}, Reason: {e}"
         )
         raise
-    finally:
-        discover_mclag(device_ip)
+    finally: 
+            discover_mclag(device_ip)
 
 
 def remove_mclag_domain_fast_convergence(device_ip: str, domain_id: int):
@@ -459,8 +459,8 @@ def remove_mclag_domain_fast_convergence(device_ip: str, domain_id: int):
             f"MCLAG domain fast convergence deletion failed on domain_id : {domain_id} and device_ip : {device_ip}, Reason: {e} "
         )
         raise
-    finally:
-        discover_mclag(device_ip)
+    finally: 
+            discover_mclag(device_ip)
 
 
 def add_mclag_domain_fast_convergence(device_ip: str, domain_id: int):
@@ -481,5 +481,5 @@ def add_mclag_domain_fast_convergence(device_ip: str, domain_id: int):
             f"MCLAG domain fast convergence deletion failed on domain_id : {domain_id} and device_ip : {device_ip}, Reason: {e} "
         )
         raise
-    finally:
-        discover_mclag(device_ip)
+    finally: 
+            discover_mclag(device_ip)

--- a/orca_nw_lib/mclag.py
+++ b/orca_nw_lib/mclag.py
@@ -193,7 +193,7 @@ def get_mclags(
 
 def config_mclag(
     device_ip: int,
-    domain_id: int = None,
+    domain_id: int,
     source_addr: str = None,
     peer_addr: str = None,
     peer_link: str = None,

--- a/orca_nw_lib/mclag_db.py
+++ b/orca_nw_lib/mclag_db.py
@@ -117,18 +117,19 @@ def create_mclag_peerlink_relations_in_db():
 
             peer_addr = mclag_local.peer_addr
             mclag_remote = (
-                mcl_r[0] if (mcl_r := get_mclag_of_device_from_db(peer_addr)) else None
+                mcl_r[0] if peer_addr and (mcl_r := get_mclag_of_device_from_db(peer_addr)) else None
             )
             peer_link_remote = mclag_remote.peer_link if mclag_remote else None
-            port_chnl_remote = get_port_chnl_of_device_from_db(
-                peer_addr, peer_link_remote
-            )
-            if port_chnl_remote:
-                mclag_remote.peer_link_node.connect(port_chnl_remote)
+            if peer_addr and peer_link_remote:
+                port_chnl_remote = get_port_chnl_of_device_from_db(
+                    peer_addr, peer_link_remote
+                )
+                if port_chnl_remote:
+                    mclag_remote.peer_link_node.connect(port_chnl_remote)
 
-            port_chnl_local.peer_link.connect(
-                port_chnl_remote
-            ) if port_chnl_local and port_chnl_remote else None
+                port_chnl_local.peer_link.connect(
+                    port_chnl_remote
+                ) if port_chnl_local and port_chnl_remote else None
 
 
 def copy_mclag_obj_props(target_obj: MCLAG, src_obj: MCLAG):

--- a/orca_nw_lib/mclag_gnmi.py
+++ b/orca_nw_lib/mclag_gnmi.py
@@ -47,17 +47,17 @@ def get_mclag_domain_path() -> Path:
 
 
 def config_mclag_domain_on_device(
-        device_ip: int = None,
-        domain_id: int= None,
-        source_addr: str= None,
-        peer_addr: str= None,
-        peer_link: str= None,
-        mclag_sys_mac: str= None,
-        keepalive_int: int = 1,
-        session_timeout: int = 30,
-        delay_restore: int = 300,
-        session_vrf: str = None,
-        fast_convergence: MclagFastConvergence = None
+    device_ip: int,
+    domain_id: int = None,
+    source_addr: str = None,
+    peer_addr: str = None,
+    peer_link: str = None,
+    mclag_sys_mac: str = None,
+    keepalive_int: int = 1,
+    session_timeout: int = 30,
+    delay_restore: int = 300,
+    session_vrf: str = None,
+    fast_convergence: MclagFastConvergence = None,
 ):
     """
     Configure the MCLAG domain on a device.
@@ -94,128 +94,122 @@ def config_mclag_domain_on_device(
         mc_lag.get("config").update({"domain-id": domain_id})
         if source_addr:
             payload = {
-                "openconfig-mclag:mclag-domain": 
-                    [
+                "openconfig-mclag:mclag-domain": [
                     {
                         "domain-id": domain_id,
                         "config": {
                             "domain-id": domain_id,
                             "source-address": source_addr,
-                        }
+                        },
                     }
-                    ]
-                }
+                ]
+            }
             updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
 
         if peer_addr:
             payload = {
-                "openconfig-mclag:mclag-domain": 
-                    [
+                "openconfig-mclag:mclag-domain": [
                     {
                         "domain-id": domain_id,
                         "config": {
                             "domain-id": domain_id,
                             "peer-address": peer_addr,
-                        }
+                        },
                     }
-                    ]
-                }
+                ]
+            }
             updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
-        
+
         if peer_link:
             payload = {
-                "openconfig-mclag:mclag-domain": 
-                    [
+                "openconfig-mclag:mclag-domain": [
                     {
                         "domain-id": domain_id,
                         "config": {
                             "domain-id": domain_id,
                             "peer-link": peer_link,
-                        }
+                        },
                     }
-                    ]
-                }
+                ]
+            }
             updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
-        
+
         if mclag_sys_mac:
             payload = {
-                "openconfig-mclag:mclag-domain": 
-                    [
+                "openconfig-mclag:mclag-domain": [
                     {
                         "domain-id": domain_id,
                         "config": {
                             "domain-id": domain_id,
                             "mclag-system-mac": mclag_sys_mac,
-                        }
+                        },
                     }
-                    ]
-                }
+                ]
+            }
             updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
-        
+
         if keepalive_int:
             payload = {
-                "openconfig-mclag:mclag-domain": 
-                    [
+                "openconfig-mclag:mclag-domain": [
                     {
                         "domain-id": domain_id,
                         "config": {
                             "domain-id": domain_id,
                             "keepalive-interval": keepalive_int,
-                        }
+                        },
                     }
-                    ]
-                }
+                ]
+            }
             updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
 
         if session_timeout:
             payload = {
-                "openconfig-mclag:mclag-domain": 
-                    [
+                "openconfig-mclag:mclag-domain": [
                     {
                         "domain-id": domain_id,
                         "config": {
                             "domain-id": domain_id,
                             "session-timeout": session_timeout,
-                        }
+                        },
                     }
-                    ]
-                }
+                ]
+            }
             updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
 
         if delay_restore:
             payload = {
-                "openconfig-mclag:mclag-domain": 
-                    [
+                "openconfig-mclag:mclag-domain": [
                     {
                         "domain-id": domain_id,
                         "config": {
                             "domain-id": domain_id,
                             "delay-restore": delay_restore,
-                        }
+                        },
                     }
-                    ]
-                }
+                ]
+            }
             updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
         if session_vrf:
             payload = {
-                "openconfig-mclag:mclag-domain": 
-                    [
+                "openconfig-mclag:mclag-domain": [
                     {
                         "domain-id": domain_id,
                         "config": {
                             "domain-id": domain_id,
                             "session-vrf": session_vrf,
-                        }
+                        },
                     }
-                    ]
-                }
+                ]
+            }
             updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
 
     # fast convergence can only be enabled if its disable it needs to be deleted
     if fast_convergence == MclagFastConvergence.enable:
         updates.append(config_mclag_domain_fast_convergence_on_device(domain_id))
     if fast_convergence == MclagFastConvergence.disable:
-        remove_mclag_domain_fast_convergence_on_device(device_ip=device_ip, domain_id=domain_id)
+        remove_mclag_domain_fast_convergence_on_device(
+            device_ip=device_ip, domain_id=domain_id
+        )
     return send_gnmi_set(
         create_req_for_update(updates),
         device_ip,
@@ -223,7 +217,7 @@ def config_mclag_domain_on_device(
 
 
 def config_mclag_member_on_device(
-        device_ip: str, mclag_domain_id: int, port_chnl_name: str
+    device_ip: str, mclag_domain_id: int, port_chnl_name: str
 ):
     """
     Configures the MCLAG member port channel on a specific device.
@@ -358,7 +352,7 @@ def get_mclag_config_from_device(device_ip: str):
         device_ip (str): The IP address of the device to retrieve the configuration from.
 
     Returns:
-        The MCLAG configuration as returned by the `send_gnmi_get` function with the 
+        The MCLAG configuration as returned by the `send_gnmi_get` function with the
         specified device IP and MCLAG path.
 
     Raises:
@@ -402,10 +396,7 @@ def config_mclag_domain_fast_convergence_on_device(domain_id: int):
     path = get_sonic_mclag_domain_list_path(domain_id)
     req_body = {
         "sonic-mclag:MCLAG_DOMAIN_LIST": [
-            {
-                "domain_id": domain_id,
-                "fast_convergence": "enable"
-            }
+            {"domain_id": domain_id, "fast_convergence": "enable"}
         ]
     }
     return create_gnmi_update(path=path, val=req_body)
@@ -424,9 +415,7 @@ def get_mclag_domain_fast_convergence_from_device(device_ip: str, domain_id: int
     """
     return send_gnmi_get(
         device_ip=device_ip,
-        path=[
-            get_sonic_mclag_domain_list_path(domain_id=domain_id)
-        ]
+        path=[get_sonic_mclag_domain_list_path(domain_id=domain_id)],
     )
 
 
@@ -446,10 +435,7 @@ def remove_mclag_domain_fast_convergence_on_device(device_ip: str, domain_id: in
     """
     path = get_sonic_mclag_domain_list_path(domain_id)
     path.elem.append(PathElem(name="fast_convergence"))
-    return send_gnmi_set(
-        req=get_gnmi_del_req(path=path),
-        device_ip=device_ip
-    )
+    return send_gnmi_set(req=get_gnmi_del_req(path=path), device_ip=device_ip)
 
 
 def add_mclag_domain_fast_convergence_on_device(device_ip: str, domain_id: int):
@@ -472,5 +458,5 @@ def add_mclag_domain_fast_convergence_on_device(device_ip: str, domain_id: int):
         req=create_req_for_update(
             [config_mclag_domain_fast_convergence_on_device(domain_id)]
         ),
-        device_ip=device_ip
+        device_ip=device_ip,
     )

--- a/orca_nw_lib/mclag_gnmi.py
+++ b/orca_nw_lib/mclag_gnmi.py
@@ -211,8 +211,6 @@ def config_mclag_domain_on_device(
                 }
             updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
 
-    print('===', updates)
-
     # fast convergence can only be enabled if its disable it needs to be deleted
     if fast_convergence == MclagFastConvergence.enable:
         updates.append(config_mclag_domain_fast_convergence_on_device(domain_id))

--- a/orca_nw_lib/mclag_gnmi.py
+++ b/orca_nw_lib/mclag_gnmi.py
@@ -48,7 +48,7 @@ def get_mclag_domain_path() -> Path:
 
 def config_mclag_domain_on_device(
     device_ip: int,
-    domain_id: int = None,
+    domain_id: int,
     source_addr: str = None,
     peer_addr: str = None,
     peer_link: str = None,
@@ -88,51 +88,32 @@ def config_mclag_domain_on_device(
             }
         ]
     }
+    config_node = mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"]
     updates = []
-    for mc_lag in mclag_config_json.get("openconfig-mclag:mclag-domain"):
-        mc_lag.update({"domain-id": domain_id})
-        mc_lag.get("config").update({"domain-id": domain_id})
+    if source_addr:
+        config_node["source-address"] = source_addr
+    if peer_addr:
+        config_node["peer-address"] = peer_addr
 
-        if source_addr:
-            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"][
-                "source-address"
-            ] = source_addr
-        if peer_addr:
-            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"][
-                "peer-address"
-            ] = peer_addr
+    if peer_link:
+        config_node["peer-link"] = peer_link
 
-        if peer_link:
-            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"][
-                "peer-link"
-            ] = peer_link
+    if mclag_sys_mac:
+        config_node["mclag-system-mac"] = mclag_sys_mac
 
-        if mclag_sys_mac:
-            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"][
-                "mclag-system-mac"
-            ] = mclag_sys_mac
+    if keepalive_int:
+        config_node["keepalive-interval"] = keepalive_int
 
-        if keepalive_int:
-            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"][
-                "keepalive-interval"
-            ] = keepalive_int
+    if session_timeout:
+        config_node["session-timeout"] = session_timeout
 
-        if session_timeout:
-            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"][
-                "session-timeout"
-            ] = session_timeout
+    if delay_restore:
+        config_node["delay-restore"] = delay_restore
 
-        if delay_restore:
-            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"][
-                "delay-restore"
-            ] = delay_restore
+    if session_vrf:
+        config_node["session-vrf"] = session_vrf
 
-        if session_vrf:
-            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"][
-                "session-vrf"
-            ] = session_vrf
-
-        updates.append(create_gnmi_update(get_mclag_domain_path(), mclag_config_json))
+    updates.append(create_gnmi_update(get_mclag_domain_path(), mclag_config_json))
 
     # fast convergence can only be enabled if its disable it needs to be deleted
     if fast_convergence == MclagFastConvergence.enable:

--- a/orca_nw_lib/mclag_gnmi.py
+++ b/orca_nw_lib/mclag_gnmi.py
@@ -47,15 +47,15 @@ def get_mclag_domain_path() -> Path:
 
 
 def config_mclag_domain_on_device(
-        device_ip: str,
-        domain_id: int,
-        source_addr: str,
-        peer_addr: str,
-        peer_link: str,
-        mclag_sys_mac: str,
-        keepalive_int: int = None,
-        session_timeout: int = None,
-        delay_restore: int = None,
+        device_ip: int = None,
+        domain_id: int= None,
+        source_addr: str= None,
+        peer_addr: str= None,
+        peer_link: str= None,
+        mclag_sys_mac: str= None,
+        keepalive_int: int = 1,
+        session_timeout: int = 30,
+        delay_restore: int = 300,
         session_vrf: str = None,
         fast_convergence: MclagFastConvergence = None
 ):
@@ -81,13 +81,9 @@ def config_mclag_domain_on_device(
     mclag_config_json = {
         "openconfig-mclag:mclag-domain": [
             {
-                "domain-id": 0,
+                "domain-id": domain_id,
                 "config": {
-                    "domain-id": 0,
-                    "source-address": "string",
-                    "peer-address": "string",
-                    "peer-link": "string",
-                    "mclag-system-mac": "string",
+                    "domain-id": domain_id,
                 },
             }
         ]
@@ -96,19 +92,126 @@ def config_mclag_domain_on_device(
     for mc_lag in mclag_config_json.get("openconfig-mclag:mclag-domain"):
         mc_lag.update({"domain-id": domain_id})
         mc_lag.get("config").update({"domain-id": domain_id})
-        mc_lag.get("config").update({"source-address": source_addr})
-        mc_lag.get("config").update({"peer-address": peer_addr})
-        mc_lag.get("config").update({"peer-link": peer_link})
-        mc_lag.get("config").update({"mclag-system-mac": mclag_sys_mac})
+        if source_addr:
+            payload = {
+                "openconfig-mclag:mclag-domain": 
+                    [
+                    {
+                        "domain-id": domain_id,
+                        "config": {
+                            "domain-id": domain_id,
+                            "source-address": source_addr,
+                        }
+                    }
+                    ]
+                }
+            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+
+        if peer_addr:
+            payload = {
+                "openconfig-mclag:mclag-domain": 
+                    [
+                    {
+                        "domain-id": domain_id,
+                        "config": {
+                            "domain-id": domain_id,
+                            "peer-address": peer_addr,
+                        }
+                    }
+                    ]
+                }
+            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+        
+        if peer_link:
+            payload = {
+                "openconfig-mclag:mclag-domain": 
+                    [
+                    {
+                        "domain-id": domain_id,
+                        "config": {
+                            "domain-id": domain_id,
+                            "peer-link": peer_link,
+                        }
+                    }
+                    ]
+                }
+            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+        
+        if mclag_sys_mac:
+            payload = {
+                "openconfig-mclag:mclag-domain": 
+                    [
+                    {
+                        "domain-id": domain_id,
+                        "config": {
+                            "domain-id": domain_id,
+                            "mclag-system-mac": mclag_sys_mac,
+                        }
+                    }
+                    ]
+                }
+            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+        
         if keepalive_int:
-            mc_lag.get("config").update({"keepalive-interval": keepalive_int})
+            payload = {
+                "openconfig-mclag:mclag-domain": 
+                    [
+                    {
+                        "domain-id": domain_id,
+                        "config": {
+                            "domain-id": domain_id,
+                            "keepalive-interval": keepalive_int,
+                        }
+                    }
+                    ]
+                }
+            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+
         if session_timeout:
-            mc_lag.get("config").update({"session-timeout": session_timeout})
+            payload = {
+                "openconfig-mclag:mclag-domain": 
+                    [
+                    {
+                        "domain-id": domain_id,
+                        "config": {
+                            "domain-id": domain_id,
+                            "session-timeout": session_timeout,
+                        }
+                    }
+                    ]
+                }
+            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+
         if delay_restore:
-            mc_lag.get("config").update({"delay-restore": delay_restore})
+            payload = {
+                "openconfig-mclag:mclag-domain": 
+                    [
+                    {
+                        "domain-id": domain_id,
+                        "config": {
+                            "domain-id": domain_id,
+                            "delay-restore": delay_restore,
+                        }
+                    }
+                    ]
+                }
+            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
         if session_vrf:
-            mc_lag.get("config").update({"session-vrf": session_vrf})
-    updates.append(create_gnmi_update(get_mclag_domain_path(), mclag_config_json))
+            payload = {
+                "openconfig-mclag:mclag-domain": 
+                    [
+                    {
+                        "domain-id": domain_id,
+                        "config": {
+                            "domain-id": domain_id,
+                            "session-vrf": session_vrf,
+                        }
+                    }
+                    ]
+                }
+            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+
+    print('===', updates)
 
     # fast convergence can only be enabled if its disable it needs to be deleted
     if fast_convergence == MclagFastConvergence.enable:

--- a/orca_nw_lib/mclag_gnmi.py
+++ b/orca_nw_lib/mclag_gnmi.py
@@ -92,116 +92,31 @@ def config_mclag_domain_on_device(
     for mc_lag in mclag_config_json.get("openconfig-mclag:mclag-domain"):
         mc_lag.update({"domain-id": domain_id})
         mc_lag.get("config").update({"domain-id": domain_id})
+        
         if source_addr:
-            payload = {
-                "openconfig-mclag:mclag-domain": [
-                    {
-                        "domain-id": domain_id,
-                        "config": {
-                            "domain-id": domain_id,
-                            "source-address": source_addr,
-                        },
-                    }
-                ]
-            }
-            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
-
+            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"]["source-address"] = source_addr
         if peer_addr:
-            payload = {
-                "openconfig-mclag:mclag-domain": [
-                    {
-                        "domain-id": domain_id,
-                        "config": {
-                            "domain-id": domain_id,
-                            "peer-address": peer_addr,
-                        },
-                    }
-                ]
-            }
-            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"]["peer-address"] = peer_addr
 
         if peer_link:
-            payload = {
-                "openconfig-mclag:mclag-domain": [
-                    {
-                        "domain-id": domain_id,
-                        "config": {
-                            "domain-id": domain_id,
-                            "peer-link": peer_link,
-                        },
-                    }
-                ]
-            }
-            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"]["peer-link"] = peer_link
 
         if mclag_sys_mac:
-            payload = {
-                "openconfig-mclag:mclag-domain": [
-                    {
-                        "domain-id": domain_id,
-                        "config": {
-                            "domain-id": domain_id,
-                            "mclag-system-mac": mclag_sys_mac,
-                        },
-                    }
-                ]
-            }
-            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"]["mclag-system-mac"] = mclag_sys_mac
 
         if keepalive_int:
-            payload = {
-                "openconfig-mclag:mclag-domain": [
-                    {
-                        "domain-id": domain_id,
-                        "config": {
-                            "domain-id": domain_id,
-                            "keepalive-interval": keepalive_int,
-                        },
-                    }
-                ]
-            }
-            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"]["keepalive-interval"] = keepalive_int
 
         if session_timeout:
-            payload = {
-                "openconfig-mclag:mclag-domain": [
-                    {
-                        "domain-id": domain_id,
-                        "config": {
-                            "domain-id": domain_id,
-                            "session-timeout": session_timeout,
-                        },
-                    }
-                ]
-            }
-            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"]["session-timeout"] = session_timeout
 
         if delay_restore:
-            payload = {
-                "openconfig-mclag:mclag-domain": [
-                    {
-                        "domain-id": domain_id,
-                        "config": {
-                            "domain-id": domain_id,
-                            "delay-restore": delay_restore,
-                        },
-                    }
-                ]
-            }
-            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"]["delay-restore"] = delay_restore
+            
         if session_vrf:
-            payload = {
-                "openconfig-mclag:mclag-domain": [
-                    {
-                        "domain-id": domain_id,
-                        "config": {
-                            "domain-id": domain_id,
-                            "session-vrf": session_vrf,
-                        },
-                    }
-                ]
-            }
-            updates.append(create_gnmi_update(get_mclag_domain_path(), payload))
+            mclag_config_json["openconfig-mclag:mclag-domain"][0]["config"]["session-vrf"] = session_vrf
+
+        updates.append(create_gnmi_update(get_mclag_domain_path(), mclag_config_json))
 
     # fast convergence can only be enabled if its disable it needs to be deleted
     if fast_convergence == MclagFastConvergence.enable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.15"
+version = "1.3.16"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.17"
+version = "1.3.18"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.18"
+version = "1.3.19"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"


### PR DESCRIPTION
related [#63](https://github.com/STORDIS/orca_nw_lib/issues/63)

added functionality which will create mclag only with domain id and any one other field
added default values in case of null configurations
fixed the discovery issue which was getting trigged in case of null peer_address
