### PR TITLE
Issue in PortChannel - Removing given vlan members from port channel #76

### DIFF
--- a/orca_nw_lib/gnmi_util.py
+++ b/orca_nw_lib/gnmi_util.py
@@ -119,6 +119,10 @@ def get_gnmi_del_req(path: Path):
     return SetRequest(delete=[path])
 
 
+def get_gnmi_del_reqs(paths: list[Path]):
+    return SetRequest(delete=paths)
+
+
 def send_gnmi_set(req: SetRequest, device_ip: str):
     try:
         device_gnmi_stub = getGrpcStubs(device_ip)

--- a/orca_nw_lib/port_chnl.py
+++ b/orca_nw_lib/port_chnl.py
@@ -198,16 +198,7 @@ def del_port_chnl(device_ip: str, chnl_name: str = None):
     port_chnl_list = port_chnl if isinstance(port_chnl, list) else [port_chnl]
     try:
         for chnl in [item for item in port_chnl_list if item is not None] or []:
-            for mem_if in get_port_chnl_members(device_ip, chnl.get("lag_name")) or []:
-                if mem_if.get("name"):
-                    del_port_chnl_mem(
-                        device_ip, chnl.get("lag_name"), mem_if.get("name")
-                    )
             if chnl.get("lag_name"):
-                # port channel vlan members and  ip address must be removed before deleting port channel.
-                # if not it throws error given instance is in use.
-                delete_port_channel_member_vlan_from_device(device_ip=device_ip, port_channel_name=chnl.get("lag_name"))
-                remove_all_port_channel_vlan_member(device_ip, chnl.get("lag_name"))
                 del_port_chnl_from_device(device_ip, chnl.get("lag_name"))
     except Exception as e:
         _logger.error(

--- a/orca_nw_lib/port_chnl.py
+++ b/orca_nw_lib/port_chnl.py
@@ -19,6 +19,7 @@ from .port_chnl_gnmi import (
     get_port_chnls_info_from_device,
     remove_port_chnl_member,
     delete_port_channel_member_vlan_from_device,
+    delete_all_port_channel_member_vlan_from_device,
     remove_port_channel_ip_from_device,
     add_port_chnl_valn_members_on_device,
     get_port_channel_ip_details_from_device,
@@ -206,7 +207,7 @@ def del_port_chnl(device_ip: str, chnl_name: str = None):
                 # port channel vlan members and  ip address must be removed before deleting port channel.
                 # if not it throws error given instance is in use.
                 delete_port_channel_member_vlan_from_device(device_ip=device_ip, port_channel_name=chnl.get("lag_name"))
-                remove_port_channel_ip_from_device(device_ip, chnl.get("lag_name"))
+                remove_all_port_channel_vlan_member(device_ip, chnl.get("lag_name"))
                 del_port_chnl_from_device(device_ip, chnl.get("lag_name"))
     except Exception as e:
         _logger.error(
@@ -347,9 +348,10 @@ def remove_port_chnl_ip(device_ip: str, chnl_name: str, ip_address: str = None):
         discover_port_chnl(device_ip)
 
 
-def remove_port_channel_vlan_member(device_ip: str, chnl_name: str, access_vlan: int = None, trunk_vlans: list[int] = None):
+def remove_port_channel_vlan_member(device_ip: str, chnl_name: str, access_vlan: int = None,
+                                    trunk_vlans: list[int] = None):
     """
-    Removes all VLAN members from a port channel on a device.
+    Removes VLAN members from a port channel on a device.
 
     Args:
         device_ip (str): The IP address of the device.
@@ -362,6 +364,26 @@ def remove_port_channel_vlan_member(device_ip: str, chnl_name: str, access_vlan:
     """
     try:
         delete_port_channel_member_vlan_from_device(device_ip, chnl_name, access_vlan, trunk_vlans)
+    except Exception as e:
+        _logger.error(f"Port Channel Vlan members removal failed on device {device_ip}, Reason: {e}")
+        raise
+    finally:
+        discover_port_chnl(device_ip)
+
+
+def remove_all_port_channel_vlan_member(device_ip: str, chnl_name: str):
+    """
+    Removes all VLAN members from a port channel on a device.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        chnl_name (str): The name of the port channel.
+
+    Returns:
+        None
+    """
+    try:
+        delete_all_port_channel_member_vlan_from_device(device_ip, chnl_name)
     except Exception as e:
         _logger.error(f"Port Channel Vlan members removal failed on device {device_ip}, Reason: {e}")
         raise

--- a/orca_nw_lib/port_chnl.py
+++ b/orca_nw_lib/port_chnl.py
@@ -347,19 +347,21 @@ def remove_port_chnl_ip(device_ip: str, chnl_name: str, ip_address: str = None):
         discover_port_chnl(device_ip)
 
 
-def remove_port_channel_vlan_member(device_ip: str, chnl_name: str):
+def remove_port_channel_vlan_member(device_ip: str, chnl_name: str, access_vlan: int = None, trunk_vlans: list[int] = None):
     """
     Removes all VLAN members from a port channel on a device.
 
     Args:
         device_ip (str): The IP address of the device.
         chnl_name (str): The name of the port channel.
+        access_vlan (int): The VLAN ID to be removed as access VLAN.
+        trunk_vlans (list[int], optional): The list of VLAN IDs to be removed as trunk VLANs. Defaults to None.
 
     Returns:
         None
     """
     try:
-        delete_port_channel_member_vlan_from_device(device_ip, chnl_name)
+        delete_port_channel_member_vlan_from_device(device_ip, chnl_name, access_vlan, trunk_vlans)
     except Exception as e:
         _logger.error(f"Port Channel Vlan members removal failed on device {device_ip}, Reason: {e}")
         raise

--- a/orca_nw_lib/port_chnl_gnmi.py
+++ b/orca_nw_lib/port_chnl_gnmi.py
@@ -517,9 +517,22 @@ def delete_port_channel_member_vlan_from_device(device_ip: str, port_channel_nam
     if trunk_vlans:
         for i in format_and_get_trunk_vlans(trunk_vlans):
             paths.append(get_gnmi_path(f"openconfig-interfaces:interfaces/interface[name={port_channel_name}]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans[trunk-vlans={i}]"))
-    if not access_vlan and not trunk_vlans:
-        paths.append(get_port_channel_vlan_memebers_path(port_channel_name=port_channel_name))
     return send_gnmi_set(req=get_gnmi_del_reqs(paths), device_ip=device_ip)
+
+
+def delete_all_port_channel_member_vlan_from_device(device_ip: str, port_channel_name: str):
+    """
+    Deletes all VLAN members of a port channel from the device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        port_channel_name (str): The name of the port channel.
+
+    Returns:
+        The result of sending a GNMI set request for deleting all VLAN members of the port channel.
+    """
+    path = get_port_channel_vlan_memebers_path(port_channel_name=port_channel_name)
+    return send_gnmi_set(get_gnmi_del_req(path=path), device_ip=device_ip)
 
 
 def get_port_channel_ip_path(port_channel_name: str):

--- a/orca_nw_lib/port_chnl_gnmi.py
+++ b/orca_nw_lib/port_chnl_gnmi.py
@@ -517,7 +517,7 @@ def delete_port_channel_member_vlan_from_device(device_ip: str, port_channel_nam
     if trunk_vlans:
         for i in format_and_get_trunk_vlans(trunk_vlans):
             paths.append(get_gnmi_path(f"openconfig-interfaces:interfaces/interface[name={port_channel_name}]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans[trunk-vlans={i}]"))
-    return send_gnmi_set(req=get_gnmi_del_reqs(paths), device_ip=device_ip)
+    return send_gnmi_set(req=get_gnmi_del_reqs(paths), device_ip=device_ip) if paths else None
 
 
 def delete_all_port_channel_member_vlan_from_device(device_ip: str, port_channel_name: str):

--- a/orca_nw_lib/port_chnl_gnmi.py
+++ b/orca_nw_lib/port_chnl_gnmi.py
@@ -4,7 +4,8 @@ from orca_nw_lib.gnmi_util import (
     create_gnmi_update,
     create_req_for_update,
     send_gnmi_get,
-    send_gnmi_set, get_gnmi_del_reqs,
+    send_gnmi_set,
+    get_gnmi_del_reqs,
 )
 from orca_nw_lib.portgroup_gnmi import get_port_chnl_mem_base_path
 from orca_nw_lib.utils import get_logging, validate_and_get_ip_prefix, format_and_get_trunk_vlans

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.19"
+version = "1.3.21"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.18"
+version = "1.3.19"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"


### PR DESCRIPTION
Fixes #76 

Issues :

Adding addtional functionaltity to removing given vlan members from port channel.
- code to deleting given access / trunk vlans.
- implementing in test cases to check it.

Fixes :

- modifying code to delete port channel vlan members.
- added function to delete mutiple delete requests - get_gnmi_del_reqs
- added test case to delete access valn or trunk vlan and both.