### PR TITLE
STP Configuration in ORCA (New Tab) #57

### DIFF
--- a/orca_nw_lib/common.py
+++ b/orca_nw_lib/common.py
@@ -124,3 +124,32 @@ class MclagFastConvergence(str, Enum):
 
     def __str__(self) -> str:
         return self.name
+
+
+class STPEnabledProtocol(str, Enum):
+    MSTP = auto()
+    RAPID_PVST = auto()
+    RSTP = auto()
+    PVST = auto()
+
+    @staticmethod
+    def get_enum_from_str(name: str):
+        return STPEnabledProtocol[name] if name in STPEnabledProtocol.__members__ else None
+
+    def get_oc_val(self):
+        return f"openconfig-spanning-tree-ext:{self.name}"
+
+    @staticmethod
+    def getEnabledProtocolStrFromOCStr(oc_str):
+        return oc_str.split(":")[1] if oc_str else None
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.name == other.name
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __str__(self) -> str:
+        return self.name

--- a/orca_nw_lib/discovery.py
+++ b/orca_nw_lib/discovery.py
@@ -14,6 +14,7 @@ from .bgp import discover_bgp, discover_bgp_af_global
 from .mclag import discover_mclag, discover_mclag_gw_macs
 
 from .port_chnl import discover_port_chnl
+from .stp import discover_stp
 from .vlan import discover_vlan
 from .graph_db_models import Device
 from .lldp import create_lldp_relations_in_db
@@ -115,6 +116,12 @@ def discover_nw_features(device_ip: str):
     except Exception as e:
         report.append(
             f"BGP Global Discovery Failed on device {device_ip}, Reason: {e}"
+        )
+    try:
+        discover_stp(device_ip)
+    except Exception as e:
+        report.append(
+            f"STP Discovery Failed on device {device_ip}, Reason: {e}"
         )
     ## Once Discovered the device, Subscribe for notfications
     gnmi_subscribe(device_ip)

--- a/orca_nw_lib/graph_db_models.py
+++ b/orca_nw_lib/graph_db_models.py
@@ -17,7 +17,7 @@ class Device(StructuredNode):
 
     img_name = StringProperty()
     mgt_intf = StringProperty()
-    mgt_ip = StringProperty(required = True)
+    mgt_ip = StringProperty(required=True)
     hwsku = StringProperty()
     mac = StringProperty(unique_index=True)
     platform = StringProperty()
@@ -32,6 +32,7 @@ class Device(StructuredNode):
     vlans = RelationshipTo("Vlan", "HAS")
     mclag_gw_macs = RelationshipTo("MCLAG_GW_MAC", "HAS")
     bgp_global_af = RelationshipTo("BGP_GLOBAL_AF", "BGP_GLOBAL_AF")
+    stp_global = RelationshipTo("STP_GLOBAL", "HAS")
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -70,7 +71,7 @@ class PortChannel(StructuredNode):
     graceful_shutdown_mode = StringProperty()
     ip_address = StringProperty()
     vlan_members = JSONProperty()
-    
+
     members = RelationshipTo("Interface", "HAS_MEMBER")
     peer_link = RelationshipTo("PortChannel", "peer_link")
 
@@ -180,8 +181,8 @@ class Interface(StructuredNode):
     subInterfaces = RelationshipTo("SubInterface", "HAS")
     lldp_neighbour = RelationshipTo("Interface", "LLDP_NBR")
     alias = StringProperty()
-    lanes =StringProperty()
-    valid_speeds= StringProperty()
+    lanes = StringProperty()
+    valid_speeds = StringProperty()
     adv_speeds = StringProperty()
     link_training = StringProperty()
     autoneg = StringProperty()
@@ -311,3 +312,32 @@ class Vlan(StructuredNode):
 
     def __str__(self):
         return str(self.vlanid)
+
+
+class STP_GLOBAL(StructuredNode):
+    """
+    Represents a STP Global in the database.
+    """
+
+    device_ip = StringProperty()
+    enabled_protocol = ArrayProperty()
+    bpdu_filter = BooleanProperty()
+    loop_guard = BooleanProperty()
+    rootguard_timeout = IntegerProperty()
+    portfast = BooleanProperty()
+    max_age = IntegerProperty()
+    hello_time = IntegerProperty()
+    forwarding_delay = IntegerProperty()
+    bridge_priority = IntegerProperty()
+    disabled_vlans = ArrayProperty()
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.device_ip == other.device_ip
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.device_ip)
+
+    def __str__(self):
+        return str(self.device_ip)

--- a/orca_nw_lib/orca_nw_lib.yml
+++ b/orca_nw_lib/orca_nw_lib.yml
@@ -8,6 +8,7 @@
 # After discovering the current device next LLDP neighbor is discovered if any.
 # Then move forward to next device in the network.
 discover_networks:
+  - "10.10.229.58"
   # - "10.10.229.50"
   #- "10.10.10.1/24"
 device_username: admin # username to make gNMI connection with device defined in network above

--- a/orca_nw_lib/stp.py
+++ b/orca_nw_lib/stp.py
@@ -1,0 +1,166 @@
+from orca_nw_lib.common import STPEnabledProtocol
+from orca_nw_lib.device_db import get_device_db_obj
+from orca_nw_lib.graph_db_models import STP_GLOBAL
+from orca_nw_lib.stp_db import insert_device_stp_in_db, get_stp_global_from_db
+
+from orca_nw_lib.utils import get_logging, format_and_get_trunk_vlans
+
+from orca_nw_lib.stp_gnmi import (config_stp_global_on_device,
+                                  get_stp_global_config_from_device,
+                                  delete_stp_global_from_device, delete_stp_global_disabled_vlans_from_device)
+
+_logger = get_logging().getLogger(__name__)
+
+
+def _create_stp_graph_object(device_ip: str):
+    """
+    Create STP graph object
+
+    Args:
+        device_ip (str): The IP address of the device
+    """
+    stp_global_config = get_stp_global_config_from_device(device_ip=device_ip)
+    stp_obj_list = {}
+    members = []
+    _logger.debug(f"Retrieved stp global info from device {device_ip} {stp_global_config}")
+    stp_config_details = stp_global_config.get("openconfig-spanning-tree:config", {})
+    enabled_protocols = [
+        STPEnabledProtocol.getEnabledProtocolStrFromOCStr(i)
+        for i in stp_config_details.get("enabled-protocol", []) or []
+    ]
+    if stp_config_details and len(enabled_protocols):
+        disabled_vlans = stp_config_details.get("openconfig-spanning-tree-ext:disabled-vlans", [])
+        stp_obj_list[
+            STP_GLOBAL(
+                device_ip=device_ip,
+                enabled_protocol=enabled_protocols,
+                bpdu_filter=stp_config_details.get("bpdu-filter", None),
+                loop_guard=stp_config_details.get("loop-guard", None),
+                disabled_vlans=format_and_get_trunk_vlans(disabled_vlans) if disabled_vlans else None,
+                rootguard_timeout=stp_config_details.get("openconfig-spanning-tree-ext:rootguard-timeout", None),
+                portfast=stp_config_details.get("openconfig-spanning-tree-ext:portfast", None),
+                hello_time=stp_config_details.get("openconfig-spanning-tree-ext:hello-time", None),
+                max_age=stp_config_details.get("openconfig-spanning-tree-ext:max-age", None),
+                forwarding_delay=stp_config_details.get("openconfig-spanning-tree-ext:forwarding-delay", None),
+                bridge_priority=stp_config_details.get("openconfig-spanning-tree-ext:bridge-priority", None),
+            )
+        ] = members
+    return stp_obj_list
+
+
+def discover_stp(device_ip: str = None):
+    """
+    Discover STP on device
+
+    Args:
+        device_ip (str): The IP address of the device
+    """
+    _logger.info("Discovering STP.")
+    devices = [get_device_db_obj(device_ip)] if device_ip else get_device_db_obj()
+    for device in devices:
+        _logger.info(f"Discovering STP on device {device}.")
+        try:
+            insert_device_stp_in_db(device, _create_stp_graph_object(device.mgt_ip))
+        except Exception as e:
+            _logger.error(f"Failed to discover STP, Reason: {e}")
+            raise
+
+
+def config_stp_global(
+        device_ip: str, enabled_protocol: list, bpdu_filter: bool, bridge_priority: int,
+        max_age: int, hello_time: int, forwarding_delay: int, disabled_vlans: list[int] = None,
+        rootguard_timeout: int = None, loop_guard: bool = None, portfast: bool = None,
+):
+    """
+    Configures the STP global settings on a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        enabled_protocol (list): List of enabled STP protocols. Valid Values: PVST, MSTP, RSTP, RAPID_PVST.
+        bpdu_filter (bool): Enable/Disable BPDU filter. Valid Values: True, False.
+        bridge_priority (int): The bridge priority value. Valid Range: 0-61440, only multiples of 4096.
+        max_age (int): Maximum age value for STP. Valid Range: 6-40.
+        hello_time (int): Hello time value for STP. Valid Range: 1-10.
+        forwarding_delay (int): Forwarding delay value for STP. Valid Range: 4-30.
+        disabled_vlans (list[int], optional): List of disabled VLANs. Defaults to None.
+        rootguard_timeout (int, optional): Root guard timeout value. Valid Range to 5-600.
+        loop_guard (bool, optional): Enable/Disable loop guard. Valid Values: True, False.
+        portfast (bool, optional): Enable/Disable portfast. Valid Values: True, False.
+
+    Raises:
+        Exception: If there is an error while configuring STP on the device.
+
+    """
+    try:
+        config_stp_global_on_device(
+            device_ip=device_ip,
+            enabled_protocol=enabled_protocol,
+            bpdu_filter=bpdu_filter,
+            loop_guard=loop_guard,
+            disabled_vlans=disabled_vlans,
+            rootguard_timeout=rootguard_timeout,
+            portfast=portfast,
+            hello_time=hello_time,
+            max_age=max_age,
+            forwarding_delay=forwarding_delay,
+            bridge_priority=bridge_priority
+        )
+    except Exception as e:
+        _logger.error(f"Failed to configure STP on device {device_ip}, Reason: {e}")
+        raise
+    finally:
+        discover_stp()
+
+
+def get_stp_global_config(device_ip: str):
+    """
+    Retrieves the STP global configuration for a specific device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+
+    Returns:
+        Union[Dict[str, Any], None]: The STP global configuration properties if available, otherwise None.
+    """
+    stp = get_stp_global_from_db(device_ip)
+    return stp.__properties__ if stp else None
+
+
+def delete_stp_global_config(device_ip: str):
+    """
+    Deletes the STP global configuration on a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+
+    Raises:
+        Exception: If there is an error while deleting STP on the device.
+    """
+    try:
+        delete_stp_global_from_device(device_ip=device_ip)
+    except Exception as e:
+        _logger.error(f"Failed to delete STP on device {device_ip}, Reason: {e}")
+        raise
+    finally:
+        discover_stp()
+
+
+def delete_stp_global_config_disabled_vlans(device_ip: str, disabled_vlans: list):
+    """
+    Deletes the STP global configuration disabled VLANs on a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        disabled_vlans (list): List of disabled VLANs.
+
+    Raises:
+        Exception: If there is an error while deleting STP on the device.
+    """
+    try:
+        delete_stp_global_disabled_vlans_from_device(device_ip=device_ip, disabled_vlans=disabled_vlans)
+    except Exception as e:
+        _logger.error(f"Failed to delete STP on device {device_ip}, Reason: {e}")
+        raise
+    finally:
+        discover_stp(device_ip=device_ip)
+

--- a/orca_nw_lib/stp_db.py
+++ b/orca_nw_lib/stp_db.py
@@ -1,0 +1,85 @@
+from orca_nw_lib.device_db import get_device_db_obj
+from orca_nw_lib.graph_db_models import STP_GLOBAL, Device
+
+from orca_nw_lib.utils import get_logging
+
+_logger = get_logging().getLogger(__name__)
+
+
+def insert_device_stp_in_db(device: Device, stp_obj: dict):
+    """
+    Inserts the STP (Spanning Tree Protocol) configuration for a given device into the database.
+
+    Args:
+        device (Device): The device object for which the STP configuration is being inserted.
+        stp_obj (dict): A dictionary containing the STP configuration for the device.
+        The keys of the dictionary are the STP instances, and the values are lists of members for each STP instance.
+
+    Returns:
+        None
+    """
+    _logger.info(f"Inserting STP on device {device.mgt_ip}.")
+    for stp, members in stp_obj.items():
+        if stp_db_obj := get_stp_global_from_db(device.mgt_ip):
+            copy_stp_global_obj(stp_db_obj, stp)
+            stp_db_obj.save()
+            device.stp_global.connect(stp_db_obj)
+        else:
+            stp.save()
+            device.stp_global.connect(stp)
+    # removing stp config if it exists on db and not on device.
+    stp_obj_from_db = get_stp_global_from_db(device.mgt_ip)
+    if stp_obj_from_db not in stp_obj:
+        delete_stp_global_from_db(device_ip=device.mgt_ip)
+
+
+def copy_stp_global_obj(target_obj: STP_GLOBAL, src_obj: STP_GLOBAL):
+    """
+    Copy the properties of a source STP_GLOBAL object to a target STP_GLOBAL object.
+
+    Args:
+        target_obj (STP_GLOBAL): The target STP_GLOBAL object to copy the properties to.
+        src_obj (STP_GLOBAL): The source STP_GLOBAL object to copy the properties from.
+
+    Returns:
+        None
+    """
+    target_obj.enabled_protocol = src_obj.enabled_protocol
+    target_obj.bpdu_filter = src_obj.bpdu_filter
+    target_obj.loop_guard = src_obj.loop_guard
+    target_obj.disabled_vlans = src_obj.disabled_vlans
+    target_obj.rootguard_timeout = src_obj.rootguard_timeout
+    target_obj.portfast = src_obj.portfast
+    target_obj.hello_time = src_obj.hello_time
+    target_obj.max_age = src_obj.max_age
+    target_obj.forwarding_delay = src_obj.forwarding_delay
+    target_obj.bridge_priority = src_obj.bridge_priority
+
+
+def get_stp_global_from_db(device_ip: str):
+    """
+    Returns the STP_GLOBAL object for the specified device from the database.
+
+    Args:
+        device_ip (str): The IP address of the device for which to retrieve the STP_GLOBAL object.
+
+    Returns:
+        STP_GLOBAL: The STP_GLOBAL object for the specified device, or None if not found.
+    """
+    device = get_device_db_obj(device_ip)
+    return device.stp_global.get_or_none(device_ip=device_ip) if device else None
+
+
+def delete_stp_global_from_db(device_ip: str):
+    """
+    Deletes the STP_GLOBAL object for the specified device from the database.
+
+    Args:
+        device_ip (str): The IP address of the device for which to delete the STP_GLOBAL object.
+
+    Returns:
+        None
+    """
+    stp_obj = get_stp_global_from_db(device_ip)
+    if stp_obj:
+        stp_obj.delete()

--- a/orca_nw_lib/stp_gnmi.py
+++ b/orca_nw_lib/stp_gnmi.py
@@ -1,0 +1,120 @@
+from orca_nw_lib.gnmi_util import (get_gnmi_path,
+                                   create_gnmi_update,
+                                   send_gnmi_set,
+                                   create_req_for_update,
+                                   send_gnmi_get,
+                                   get_gnmi_del_req, get_gnmi_del_reqs)
+from orca_nw_lib.utils import format_and_get_trunk_vlans
+
+
+def get_stp_global_config_path():
+    """
+    Returns the path of the STP global config.
+    """
+    return get_gnmi_path(
+        "openconfig-spanning-tree:stp/global/config"
+    )
+
+
+def config_stp_global_on_device(
+        device_ip: str, enabled_protocol: list, bpdu_filter: bool, bridge_priority: int,
+        max_age: int, hello_time: int, forwarding_delay: int, disabled_vlans: list[int] = None,
+        rootguard_timeout: int = None, loop_guard: bool = None, portfast: bool = None,
+):
+    """
+    Configures the STP global settings on a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        enabled_protocol (list): List of enabled STP protocols. Valid Values: PVST, MSTP, RSTP, RAPID_PVST.
+        bpdu_filter (bool): Enable/Disable BPDU filter. Valid Values: True, False.
+        bridge_priority (int): The bridge priority value. Valid Range: 0-61440, only multiples of 4096.
+        max_age (int): Maximum age value for STP. Valid Range: 6-40.
+        hello_time (int): Hello time value for STP. Valid Range: 1-10.
+        forwarding_delay (int): Forwarding delay value for STP. Valid Range: 4-30.
+        disabled_vlans (list[int], optional): List of disabled VLANs. Defaults to None.
+        rootguard_timeout (int, optional): Root guard timeout value. Valid Range to 5-600.
+        loop_guard (bool, optional): Enable/Disable loop guard. Valid Values: True, False.
+        portfast (bool, optional): Enable/Disable portfast. Valid Values: True, False.
+
+    Raises:
+        Exception: If there is an error while configuring STP on the device.
+
+    """
+    request_data = {
+        "enabled-protocol": [str(i) for i in enabled_protocol],
+        "bpdu-filter": bpdu_filter,
+        "openconfig-spanning-tree-ext:hello-time": hello_time,
+        "openconfig-spanning-tree-ext:max-age": max_age,
+        "openconfig-spanning-tree-ext:forwarding-delay": forwarding_delay,
+        "openconfig-spanning-tree-ext:bridge-priority": bridge_priority,
+    }
+
+    if loop_guard is not None:
+        request_data["loop-guard"] = loop_guard
+    if rootguard_timeout is not None:
+        request_data["rootguard-timeout"] = rootguard_timeout
+    if portfast is not None:
+        request_data["portfast"] = portfast
+    if disabled_vlans is not None:
+        request_data["disabled-vlans"] = disabled_vlans
+    request = create_gnmi_update(
+        path=get_stp_global_config_path(),
+        val={"openconfig-spanning-tree:config": request_data}
+    )
+    return send_gnmi_set(create_req_for_update([request]), device_ip)
+
+
+def get_stp_global_config_from_device(device_ip: str):
+    """
+    Retrieves the global STP configuration from a specified device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+
+    Returns:
+        dict: A dictionary containing the global STP configuration.
+    """
+    return send_gnmi_get(
+        path=[get_stp_global_config_path()],
+        device_ip=device_ip
+    )
+
+
+def delete_stp_global_from_device(device_ip: str):
+    """
+    Deletes the global STP configuration from a specified device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+
+    Returns:
+        dict: A dictionary containing the global STP configuration.
+    """
+    return send_gnmi_set(
+        req=get_gnmi_del_req(
+            path=get_stp_global_config_path()
+        ),
+        device_ip=device_ip
+    )
+
+
+def delete_stp_global_disabled_vlans_from_device(device_ip: str, disabled_vlans: list):
+    """
+    Deletes the global STP configuration from a specified device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        disabled_vlans (list): List of disabled VLANs.
+
+    Returns:
+        dict: A dictionary containing the global STP configuration.
+    """
+    requests = []
+    for i in format_and_get_trunk_vlans(disabled_vlans):
+        requests.append(
+            get_gnmi_path(
+                f"/openconfig-spanning-tree:stp/global/config/openconfig-spanning-tree-ext:disabled-vlans[disabled-vlans={i}]"
+            )
+        )
+    return send_gnmi_set(req=get_gnmi_del_reqs(requests), device_ip=device_ip)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.21"
+version = "1.3.22"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"


### PR DESCRIPTION
Issues:

STP (Spanning Tree Protocol) Configuration -

- Global STP config will be a new node in DB, so a new model created with the properties received as GET operation at the path described in above cell.

- The new node stp will have a "HAS" relation with its Device node in the DB.

- A respective stp.py stp_db.py stp_gnmi.py needs to be created, Also discovery of STP global mechanism needed to be integrated in discovery.py

- orca_backend should provide CRUD rest endpoints for above.

- test cases covering operations on all the parameters.


Fixes issues:

- Added new db to save stp global configurations with has realtionship on device.
- orca_backend to support crud opetaions
- test cases for crud operations and parameters updates.
- api to delete disabled vlans.