### PR TITLE
 STP Port Config #60

### DIFF
--- a/orca_nw_lib/common.py
+++ b/orca_nw_lib/common.py
@@ -153,3 +153,86 @@ class STPEnabledProtocol(str, Enum):
 
     def __str__(self) -> str:
         return self.name
+
+
+class STPPortEdgePort(str, Enum):
+    EDGE_AUTO = auto()
+    EDGE_ENABLE = auto()
+    EDGE_DISABLE = auto()
+
+    @staticmethod
+    def get_enum_from_str(name: str):
+        return STPPortEdgePort[name] if name in STPPortEdgePort.__members__ else None
+
+    def get_oc_val(self):
+        return f"openconfig-spanning-tree-ext:{self.name}"
+
+    @staticmethod
+    def getSTPPortEdgePortStrFromOCStr(oc_str):
+        return oc_str.split(":")[1] if oc_str else None
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.name == other.name
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class STPPortLinkType(str, Enum):
+    P2P = auto()
+    SHARED = auto()
+
+    @staticmethod
+    def get_enum_from_str(name: str):
+        return STPPortLinkType[name] if name in STPPortLinkType.__members__ else None
+
+    def get_oc_val(self):
+        return f"openconfig-spanning-tree-ext:{self.name}"
+
+    @staticmethod
+    def getLinkTypeStrFromOCStr(oc_str):
+        return oc_str.split(":")[1] if oc_str else None
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.name == other.name
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class STPPortGuard(str, Enum):
+    ROOT = auto()
+    LOOP = auto()
+    NONE = auto()
+
+    @staticmethod
+    def get_enum_from_str(name: str):
+        return STPPortGuard[name] if name in STPPortGuard.__members__ else None
+
+    def get_oc_val(self):
+        return f"openconfig-spanning-tree-ext:{self.name}"
+
+    @staticmethod
+    def getPortGuardStrFromOCStr(oc_str):
+        return oc_str.split(":")[1] if oc_str else None
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.name == other.name
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __str__(self) -> str:
+        return self.name

--- a/orca_nw_lib/discovery.py
+++ b/orca_nw_lib/discovery.py
@@ -19,6 +19,7 @@ from .mclag import discover_mclag, discover_mclag_gw_macs
 
 from .port_chnl import discover_port_chnl
 from .stp import discover_stp
+from .stp_port import discover_stp_port
 from .vlan import discover_vlan
 from .utils import get_logging, get_networks, ping_ok
 
@@ -81,6 +82,13 @@ def discover_nw_features(device_ip: str):
     except Exception as e:
         report.append(
             f"STP Discovery Failed on device {device_ip}, Reason: {e}"
+        )
+
+    try:
+        discover_stp_port(device_ip)
+    except Exception as e:
+        report.append(
+            f"STP Port Discovery Failed on device {device_ip}, Reason: {e}"
         )
     ## Once Discovered the device, Subscribe for notfications
     gnmi_subscribe(device_ip)

--- a/orca_nw_lib/gnmi_sub.py
+++ b/orca_nw_lib/gnmi_sub.py
@@ -463,8 +463,8 @@ def get_subscription_path_for_config_change(device_ip: str):
             )
         )
 
-    # ON_CHANGE subscription mode is not supported only SAMPLE subscription mode is supported.
-    # re discovery of the device is the best choice for stp.
+    # ON_CHANGE subscription mode is not supported for stp global config,  only SAMPLE subscription mode is supported.
+    # re discovery of stp global config is being done for every config change on stp global config via ORCA.
 
     # subscriptions.append(
     #     Subscription(

--- a/orca_nw_lib/gnmi_sub.py
+++ b/orca_nw_lib/gnmi_sub.py
@@ -33,7 +33,8 @@ from orca_nw_lib.portgroup_gnmi import (
     _get_port_groups_base_path,
 )
 from .stp_db import set_stp_config_in_db
-from .stp_gnmi import get_stp_global_config_path
+from .stp_port_db import set_stp_port_config_in_db, delete_stp_port_member_from_db
+from .stp_port_gnmi import get_stp_port_path
 
 _logger = get_logging().getLogger(__name__)
 
@@ -196,6 +197,71 @@ def handle_stp_config(device_ip: str, resp: SubscribeResponse):
     )
 
 
+def handle_stp_port_config(device_ip: str, resp: SubscribeResponse):
+    bpdu_guard = None
+    bpdu_filter = None
+    bpdu_guard_port_shutdown = None
+    link_type = None
+    guard = None
+    edge_port = None
+    if_name = None
+    portfast = None
+    stp_enabled = None
+    uplink_fast = None
+    cost = None
+    port_priority = None
+    for del_item in resp.update.delete:
+        for ele in del_item.elem:
+            if ele.name == "interface":
+                if_name = ele.key.get("name")
+                return delete_stp_port_member_from_db(device_ip=device_ip, if_name=if_name)
+
+    for u in resp.update.update:
+        for ele in u.path.elem:
+            if ele.name == "bpdu-guard":
+                bpdu_guard = u.val.bool_val
+            if ele.name == "bpdu-filter":
+                bpdu_filter = u.val.bool_val
+            if ele.name == "bpdu-guard-port-shutdown":
+                bpdu_guard_port_shutdown = u.val.bool_val
+            if ele.name == "link-type":
+                link_type = u.val.string_val
+            if ele.name == "guard":
+                guard = u.val.string_val
+            if ele.name == "edge-port":
+                edge_port = u.val.string_val
+            if ele.name == "name":
+                if_name = u.val.string_val
+            if ele.name == "portfast":
+                portfast = u.val.bool_val
+            if ele.name == "spanning-tree-enable":
+                stp_enabled = u.val.bool_val
+            if ele.name == "uplink-fast":
+                uplink_fast = u.val.bool_val
+            if ele.name == "cost":
+                cost = u.val.uint_val
+            if ele.name == "port-priority":
+                port_priority = u.val.uint_val
+    _logger.debug(
+        f"Updating stp port {if_name} on db for {device_ip} with config bpdu_guard: {bpdu_guard}, bpdu_filter: {bpdu_filter}, bpdu_guard_port_shutdown: {bpdu_guard_port_shutdown}, link_type: {link_type}, guard: {guard}, edge_port: {edge_port}, portfast: {portfast}, stp_enabled: {stp_enabled}, uplink_fast: {uplink_fast}, cost: {cost}, port_priority: {bpdu_guard}."
+    )
+    return set_stp_port_config_in_db(
+        device_ip=device_ip,
+        if_name=if_name,
+        bpdu_guard=bpdu_guard,
+        bpdu_filter=bpdu_filter,
+        bpdu_guard_port_shutdown=bpdu_guard_port_shutdown,
+        link_type=link_type,
+        guard=guard,
+        edge_port=edge_port,
+        portfast=portfast,
+        stp_enabled=stp_enabled,
+        uplink_fast=uplink_fast,
+        cost=cost,
+        port_priority=port_priority
+    )
+
+
 def handle_update(device_ip: str, subscriptions: List[Subscription]):
     device_gnmi_stub = getGrpcStubs(device_ip)
     subscriptionlist = SubscriptionList(
@@ -231,13 +297,20 @@ def handle_update(device_ip: str, subscriptions: List[Subscription]):
                             resp,
                         )
                         handle_port_group_config_update(device_ip, resp)
-                    if ele.name == get_stp_global_config_path().elem[0].name:
+                    # if ele.name == get_stp_global_config_path().elem[0].name:
+                    #     _logger.debug(
+                    #         "gNMI subscription stp config update received from %s -> %s",
+                    #         device_ip,
+                    #         resp,
+                    #     )
+                    #     handle_stp_config(device_ip, resp)
+                    if ele.name == get_stp_port_path().elem[0].name:
                         _logger.debug(
                             "gNMI subscription stp config update received from %s -> %s",
                             device_ip,
                             resp,
                         )
-                        handle_stp_config(device_ip, resp)
+                        handle_stp_port_config(device_ip, resp)
             elif resp.sync_response:
                 global device_sync_responses
                 _logger.info(
@@ -400,6 +473,13 @@ def get_subscription_path_for_config_change(device_ip: str):
     #     )
     # )
 
+    subscriptions.append(
+        Subscription(
+            path=get_stp_port_path(),
+            mode=SubscriptionMode.ON_CHANGE
+        )
+    )
+
     return subscriptions
 
 
@@ -445,7 +525,8 @@ def gnmi_unsubscribe(device_ip: str):
     """
     sync_response = device_sync_responses.pop(device_ip, None)
     if sync_response is not None:
-        _logger.debug(f"Removed device {device_ip} with sync_response {sync_response} from device_sync_responses dictionary.")
+        _logger.debug(
+            f"Removed device {device_ip} with sync_response {sync_response} from device_sync_responses dictionary.")
     else:
         _logger.debug(f"Device {device_ip} not found in device_sync_responses dictionary.")
 
@@ -505,7 +586,8 @@ def check_gnmi_subscription_and_apply_config(config_func):
                 "Before config checking if device %s is fully subscribed to GNMI update notifications.",
                 kwargs.get("device_ip"),
             )
-            if gnmi_subscribe(ip) and sync_response_received(ip) :  ## Check if the snyc response has been received for the given device also attempt to subscribe to gNMI,
+            if gnmi_subscribe(ip) and sync_response_received(
+                    ip):  ## Check if the snyc response has been received for the given device also attempt to subscribe to gNMI,
                 # gNMI subscription will occur in case not already Subscribed.
                 result = config_func(*args, **kwargs)
                 return result

--- a/orca_nw_lib/graph_db_models.py
+++ b/orca_nw_lib/graph_db_models.py
@@ -33,6 +33,7 @@ class Device(StructuredNode):
     mclag_gw_macs = RelationshipTo("MCLAG_GW_MAC", "HAS")
     bgp_global_af = RelationshipTo("BGP_GLOBAL_AF", "BGP_GLOBAL_AF")
     stp_global = RelationshipTo("STP_GLOBAL", "HAS")
+    stp_port = RelationshipTo("STP_PORT", "HAS")
 
     def copy_properties(self, other):
         """
@@ -86,6 +87,8 @@ class PortChannel(StructuredNode):
 
     members = RelationshipTo("Interface", "HAS_MEMBER")
     peer_link = RelationshipTo("PortChannel", "peer_link")
+
+    stp_port = RelationshipTo("STP_PORT", "HAS")
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -199,6 +202,8 @@ class Interface(StructuredNode):
     link_training = StringProperty()
     autoneg = StringProperty()
     lldp_nbrs=JSONProperty() ## LLDP remote device in the format  - {nbr_ip:[Eth0,Eth1].........}
+
+    stp_port = RelationshipTo("STP_PORT", "HAS")
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -354,3 +359,33 @@ class STP_GLOBAL(StructuredNode):
 
     def __str__(self):
         return str(self.device_ip)
+
+
+class STP_PORT(StructuredNode):
+    """
+    Represents a STP Port in the database.
+    """
+
+    if_name = StringProperty()
+    edge_port = StringProperty()
+    link_type = StringProperty()
+    guard = StringProperty()
+    bpdu_guard = BooleanProperty()
+    bpdu_filter = BooleanProperty()
+    portfast = BooleanProperty()
+    uplink_fast = BooleanProperty()
+    bpdu_guard_port_shutdown = BooleanProperty()
+    cost = IntegerProperty()
+    port_priority = IntegerProperty()
+    stp_enabled = BooleanProperty()
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.if_name == other.if_name
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.if_name)
+
+    def __str__(self):
+        return str(self.if_name)

--- a/orca_nw_lib/stp_port.py
+++ b/orca_nw_lib/stp_port.py
@@ -80,29 +80,29 @@ def discover_stp_port(device_ip: str = None):
 
 @check_gnmi_subscription_and_apply_config
 def add_stp_port_members(
-        device_ip: str, if_name: str, edge_port: str = None, link_type: str = None, guard: str = None,
-        bpdu_guard: bool = None, bpdu_filter: bool = None, portfast: bool = None, uplink_fast: bool = None,
-        bpdu_guard_port_shutdown: bool = None, cost: int = None, port_priority: int = None,
-        stp_enabled: bool = None
+        device_ip: str, if_name: str, bpdu_guard: bool, uplink_fast: bool, stp_enabled: bool,
+        link_type: str = None, guard: str = None, edge_port: str = None, bpdu_filter: bool = None,
+        portfast: bool = None, bpdu_guard_port_shutdown: bool = None,
+        cost: int = None, port_priority: int = None,
+
 ):
     """
     Adds the STP port channel members on a device.
 
     Parameters:
-        device_ip (str): The IP address of the device.
-        if_name (str, optional): The interface name. Defaults to None.
-        edge_port (str, optional): The edge port. Defaults to None.
-        link_type (str, optional): The link type. Defaults to None.
-        guard (str, optional): The guard. Defaults to None.
-        bpdu_guard (str, optional): The BPDU guard. Defaults to None.
-        bpdu_filter (str, optional): The BPDU filter. Defaults to None.
-        portfast (str, optional): The portfast. Defaults to None.
-        uplink_fast (str, optional): The uplink fast. Defaults to None.
-        bpdu_guard_port_shutdown (str, optional): The BPDU guard port shutdown. Defaults to None.
-        cost (str, optional): The cost. Defaults to None.
-        port_priority (str, optional): The port priority. Defaults to None.
-        stp_enabled (str, optional): The STP enabled. Defaults to None.
-
+        device_ip (str, Required): The IP address of the device.
+        if_name (str, Required): The name of the interface.
+        bpdu_guard (bool, Required): Enable/Disable BPDU guard. Valid Values: True, False.
+        uplink_fast (bool, Required): Enable/Disable uplink fast. Valid Values: True, False.
+        stp_enabled (bool, Required): Enable/Disable STP. Valid Values: True, False.
+        edge_port (str, Optional): The name of the edge port. Valid Values: EDGE_AUTO, EDGE_ENABLE, EDGE_DISABLE.
+        link_type (str, Optional): The type of the link. Valid Values: P2P, SHARED.
+        guard (str, Optional): The guard. Valid Values: NONE, ROOT, LOOP.
+        bpdu_filter (bool, Optional): Enable/Disable BPDU filter. Valid Values: True, False.
+        portfast (bool, Optional): Enable/Disable portfast. Valid Values: True, False.
+        bpdu_guard_port_shutdown (bool, Optional): Enable/Disable BPDU guard port shutdown. Valid Values: True, False.
+        cost (int, Optional): The cost. Valid Range: 1-200000000.
+        port_priority (int, Optional): The port priority. Valid Range: 0-240.
     Raises:
         Exception: If there is an error while adding STP on the device.
     """

--- a/orca_nw_lib/stp_port.py
+++ b/orca_nw_lib/stp_port.py
@@ -1,0 +1,170 @@
+from orca_nw_lib.utils import get_logging
+
+from orca_nw_lib.common import STPPortEdgePort
+from orca_nw_lib.device_db import get_device_db_obj
+
+from orca_nw_lib.gnmi_sub import check_gnmi_subscription_and_apply_config
+from orca_nw_lib.graph_db_models import STP_PORT
+from orca_nw_lib.stp_port_db import (get_stp_port_members_from_db, insert_device_stp_port_in_db)
+from orca_nw_lib.stp_port_gnmi import (add_stp_port_members_on_device,
+                                       get_stp_port_members_from_device,
+                                       delete_stp_port_member_from_device)
+
+_logger = get_logging().getLogger(__name__)
+
+
+def _create_stp_port_graph_object(device_ip: str):
+    """
+    Creates the STP port graph object.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+
+    Returns:
+        dict: The STP port graph object.
+    """
+    try:
+        stp_port_config = get_stp_port_members_from_device(device_ip)
+    except Exception as e:
+        _logger.error(f"Error getting stp port members from device {device_ip}: {e}")
+        return {}
+    stp_port_obj_list = {}
+    members = []
+    _logger.debug(f"Retrieved stp global info from device {device_ip} {stp_port_config}")
+    stp_ports = stp_port_config.get("openconfig-spanning-tree:interface", [])
+    for port in stp_ports:
+        if_name = port.get("name")
+        config = port.get("config", {})
+        edge_port = config.get("edge-port")
+        link_type = config.get("link-type")
+        guard = config.get("guard")
+        stp_port_obj_list[
+            STP_PORT(
+                if_name=if_name,
+                edge_port=STPPortEdgePort.getSTPPortEdgePortStrFromOCStr(edge_port) if edge_port else None,
+                link_type=link_type if link_type else None,
+                guard=guard if guard else None,
+                bpdu_filter=config.get("bpdu-filter", None),
+                bpdu_guard=config.get("bpdu-guard", None),
+                bpdu_guard_port_shutdown=config.get("openconfig-spanning-tree-ext:bpdu-guard-port-shutdown", None),
+                portfast=config.get("openconfig-spanning-tree-ext:portfast", None),
+                uplink_fast=config.get("openconfig-spanning-tree-ext:uplink-fast", None),
+                cost=config.get("openconfig-spanning-tree-ext:cost", None),
+                port_priority=config.get("openconfig-spanning-tree-ext:port-priority", None),
+                stp_enabled=config.get("openconfig-spanning-tree-ext:spanning-tree-enable", None)
+            )
+        ] = members
+    return stp_port_obj_list
+
+
+def discover_stp_port(device_ip: str = None):
+    """
+    Discovers the STP port configuration on a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+
+    Returns:
+        dict: The STP port configuration.
+    """
+    _logger.info("Discovering STP Port.")
+    devices = [get_device_db_obj(device_ip)] if device_ip else get_device_db_obj()
+    for device in devices:
+        _logger.info(f"Discovering STP on device {device}.")
+        try:
+            insert_device_stp_port_in_db(device, _create_stp_port_graph_object(device.mgt_ip))
+        except Exception as e:
+            _logger.error(f"Failed to discover STP, Reason: {e}")
+            raise
+
+
+@check_gnmi_subscription_and_apply_config
+def add_stp_port_members(
+        device_ip: str, if_name: str, edge_port: str = None, link_type: str = None, guard: str = None,
+        bpdu_guard: bool = None, bpdu_filter: bool = None, portfast: bool = None, uplink_fast: bool = None,
+        bpdu_guard_port_shutdown: bool = None, cost: int = None, port_priority: int = None,
+        stp_enabled: bool = None
+):
+    """
+    Adds the STP port channel members on a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        if_name (str, optional): The interface name. Defaults to None.
+        edge_port (str, optional): The edge port. Defaults to None.
+        link_type (str, optional): The link type. Defaults to None.
+        guard (str, optional): The guard. Defaults to None.
+        bpdu_guard (str, optional): The BPDU guard. Defaults to None.
+        bpdu_filter (str, optional): The BPDU filter. Defaults to None.
+        portfast (str, optional): The portfast. Defaults to None.
+        uplink_fast (str, optional): The uplink fast. Defaults to None.
+        bpdu_guard_port_shutdown (str, optional): The BPDU guard port shutdown. Defaults to None.
+        cost (str, optional): The cost. Defaults to None.
+        port_priority (str, optional): The port priority. Defaults to None.
+        stp_enabled (str, optional): The STP enabled. Defaults to None.
+
+    Raises:
+        Exception: If there is an error while adding STP on the device.
+    """
+    try:
+        add_stp_port_members_on_device(
+            device_ip=device_ip,
+            if_name=if_name,
+            edge_port=edge_port,
+            link_type=link_type,
+            guard=guard,
+            bpdu_guard=bpdu_guard,
+            bpdu_filter=bpdu_filter,
+            portfast=portfast,
+            uplink_fast=uplink_fast,
+            bpdu_guard_port_shutdown=bpdu_guard_port_shutdown,
+            cost=cost,
+            port_priority=port_priority,
+            stp_enabled=stp_enabled
+        )
+    except Exception as e:
+        _logger.error(f"Failed to add STP Port Channel Members on device {device_ip}, Reason: {e}")
+        raise
+
+
+def get_stp_port_members(device_ip: str, if_name: str = None):
+    """
+    Retrieves the STP port members from the database.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        if_name (str, optional): The name of the interface. Defaults to None.
+
+    Returns:
+        list or dict: A list of dictionaries representing the STP port members if `if_name` is None,
+                     otherwise a dictionary representing the STP port member.
+
+    Raises:
+        None.
+    """
+    stp_port = get_stp_port_members_from_db(device_ip, if_name)
+    if stp_port:
+        if isinstance(stp_port, list):
+            return [i.__properties__ for i in stp_port]
+        else:
+            return stp_port.__properties__
+
+
+@check_gnmi_subscription_and_apply_config
+def delete_stp_port_member(device_ip: str, if_name: str):
+    """
+    Deletes the STP port channel member from the database and rediscover the STP port.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        if_name (str): The name of the interface.
+
+    Raises:
+        Exception: If there is an error while deleting the STP port channel member.
+
+    """
+    try:
+        delete_stp_port_member_from_device(device_ip, if_name)
+    except Exception as e:
+        _logger.error(f"Failed to delete STP Port Channel Member on device {device_ip}, Reason: {e}")
+        raise

--- a/orca_nw_lib/stp_port_db.py
+++ b/orca_nw_lib/stp_port_db.py
@@ -1,0 +1,164 @@
+from orca_nw_lib.port_chnl_db import get_port_chnl_of_device_from_db
+
+from orca_nw_lib.interface_db import get_interface_of_device_from_db
+
+from orca_nw_lib.graph_db_models import Device, STP_PORT
+
+from orca_nw_lib.utils import get_logging
+
+from orca_nw_lib.device_db import get_device_db_obj
+
+_logger = get_logging().getLogger(__name__)
+
+
+def set_stp_port_config_in_db(
+        device_ip: str, if_name: str = None, edge_port: str = None, link_type: str = None, guard: str = None,
+        bpdu_guard: bool = None, bpdu_filter: bool = None, portfast: bool = None, uplink_fast: bool = None,
+        bpdu_guard_port_shutdown: bool = None, cost: int = None, port_priority: int = None,
+        stp_enabled: bool = None
+):
+    """
+    Sets the STP port channel members on a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        if_name (str, optional): The interface name. Defaults to None.
+        edge_port (str, optional): The edge port. Defaults to None.
+        link_type (str, optional): The link type. Defaults to None.
+        guard (str, optional): The guard. Defaults to None.
+        bpdu_guard (str, optional): The BPDU guard. Defaults to None.
+        bpdu_filter (str, optional): The BPDU filter. Defaults to None.
+        portfast (str, optional): The portfast. Defaults to None.
+        uplink_fast (str, optional): The uplink fast. Defaults to None.
+        bpdu_guard_port_shutdown (str, optional): The BPDU guard port shutdown. Defaults to None.
+        cost (str, optional): The cost. Defaults to None.
+        port_priority (str, optional): The port priority. Defaults to None.
+        stp_enabled (str, optional): The STP enabled. Defaults to None.
+    """
+    if device_ip and if_name:
+        stp_port = STP_PORT(
+            if_name=if_name,
+            edge_port=edge_port,
+            link_type=link_type,
+            guard=guard,
+            bpdu_guard=bpdu_guard,
+            bpdu_filter=bpdu_filter,
+            portfast=portfast,
+            uplink_fast=uplink_fast,
+            bpdu_guard_port_shutdown=bpdu_guard_port_shutdown,
+            cost=cost,
+            port_priority=port_priority,
+            stp_enabled=stp_enabled
+        )
+        device = get_device_db_obj(device_ip)
+        if device:
+            insert_device_stp_port_in_db(
+                device=device, stp_port_obj={stp_port: []}
+            )
+
+
+def get_stp_port_members_from_db(device_ip: str, if_name: str = None):
+    """
+    Gets the STP port channel members from a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        if_name (str, optional): The name of the interface. Defaults to None.
+    """
+    device = get_device_db_obj(device_ip)
+    if if_name is None:
+        return device.stp_port.all() if device else None
+    else:
+        return device.stp_port.get_or_none(if_name=if_name) if device else None
+
+
+def save_to_db(device_ip: str, stp_port_obj: STP_PORT):
+    """
+    Saves the STP port channel members to a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        stp_port_obj (STP_PORT): The STP_PORT object to save.
+    """
+    device = get_device_db_obj(device_ip)
+    device.stp_port.connect(stp_port_obj)
+
+    # adding stp port interface or portchannel node in db
+    if "ethernet" in stp_port_obj.if_name.lower():
+        intfc = get_interface_of_device_from_db(device.mgt_ip, stp_port_obj.if_name)
+        intfc.stp_port.connect(stp_port_obj)
+    elif "portchannel" in stp_port_obj.if_name.lower():
+        port_chnl = get_port_chnl_of_device_from_db(device.mgt_ip, stp_port_obj.if_name)
+        port_chnl.stp_port.connect(stp_port_obj)
+
+
+def copy_stp_port_obj(target_obj: STP_PORT, src_obj: STP_PORT):
+    """
+    Copy the properties of a source STP_GLOBAL object to a target STP_GLOBAL object.
+
+    Args:
+        target_obj (STP_GLOBAL): The target STP_GLOBAL object to copy the properties to.
+        src_obj (STP_GLOBAL): The source STP_GLOBAL object to copy the properties from.
+
+    Returns:
+        None
+    """
+    target_obj.if_name = src_obj.if_name
+    target_obj.edge_port = src_obj.edge_port
+    target_obj.link_type = src_obj.link_type
+    target_obj.guard = src_obj.guard
+    target_obj.bpdu_guard = src_obj.bpdu_guard
+    target_obj.bpdu_filter = src_obj.bpdu_filter
+    target_obj.portfast = src_obj.portfast
+    target_obj.uplink_fast = src_obj.uplink_fast
+    target_obj.bpdu_guard_port_shutdown = src_obj.bpdu_guard_port_shutdown
+    target_obj.cost = src_obj.cost
+    target_obj.port_priority = src_obj.port_priority
+    target_obj.stp_enabled = src_obj.stp_enabled
+
+
+def insert_device_stp_port_in_db(device: Device, stp_port_obj: dict):
+    """
+    Insert the STP_PORT object in the database.
+
+    Args:
+        device (Device): The device object.
+        stp_port_obj (dict): The STP port object.
+    """
+    _logger.info(f"Inserting STP Port on device {device.mgt_ip}.")
+    for stp_port, members in stp_port_obj.items():
+        if existing_stp_port := get_stp_port_members_from_db(device.mgt_ip, stp_port.if_name):
+            # updating stp port node in db
+            copy_stp_port_obj(existing_stp_port, stp_port)
+            existing_stp_port.save()
+            new_port_obj = existing_stp_port
+        else:
+            # inserting stp port node in db
+            stp_port.save()
+            new_port_obj = stp_port
+
+        device.stp_port.connect(new_port_obj)
+
+        # adding stp port interface or portchannel node in db
+        if "ethernet" in new_port_obj.if_name.lower():
+            intfc = get_interface_of_device_from_db(device.mgt_ip, stp_port.if_name)
+            intfc.stp_port.connect(new_port_obj)
+        elif "portchannel" in new_port_obj.if_name.lower():
+            port_chnl = get_port_chnl_of_device_from_db(device.mgt_ip, stp_port.if_name)
+            port_chnl.stp_port.connect(new_port_obj)
+
+    # removing stp port if it exists on db and not on device.
+    stp_port_obj_from_db = get_stp_port_members_from_db(device.mgt_ip)
+    for existing_port_in_db in stp_port_obj_from_db:
+        if existing_port_in_db not in stp_port_obj:
+            delete_stp_port_member_from_db(device_ip=device.mgt_ip, if_name=existing_port_in_db.if_name)
+
+
+def delete_stp_port_member_from_db(device_ip: str, if_name: str):
+    """
+    device_ip (str): The IP address of the device.
+    if_name (str): The name of the interface.
+    """
+    stp_port = get_stp_port_members_from_db(device_ip, if_name)
+    if stp_port:
+        stp_port.delete()

--- a/orca_nw_lib/stp_port_gnmi.py
+++ b/orca_nw_lib/stp_port_gnmi.py
@@ -1,0 +1,137 @@
+from orca_nw_lib.utils import get_logging
+
+from orca_nw_lib.gnmi_util import (get_gnmi_path,
+                                   send_gnmi_set,
+                                   create_req_for_update,
+                                   create_gnmi_update,
+                                   get_gnmi_del_req,
+                                   send_gnmi_get, )
+
+_logger = get_logging().getLogger(__name__)
+
+
+def get_stp_port_path(if_name: str = None):
+    """
+    Returns the GNMi path for the specified STP port interface.
+
+    Args:
+        if_name (str, optional): The name of the STP port interface. Defaults to None.
+
+    Returns:
+        Path: The GNMi path for the specified STP port interface.
+    """
+    if if_name is None:
+        return get_gnmi_path("/openconfig-spanning-tree:stp/interfaces/interface")
+    return get_gnmi_path(
+        f"/openconfig-spanning-tree:stp/interfaces/interface[name={if_name}]"
+    )
+
+
+def add_stp_port_members_on_device(
+        device_ip: str, if_name: str = None, edge_port: str = None, link_type: str = None, guard: str = None,
+        bpdu_guard: bool = None, bpdu_filter: bool = None, portfast: bool = None, uplink_fast: bool = None,
+        bpdu_guard_port_shutdown: bool = None, cost: int = None, port_priority: int = None,
+        stp_enabled: bool = None
+):
+    """
+    Adds the STP port channel members on a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        if_name (str, optional): The name of the interface. Defaults to None.
+        edge_port (str, optional): The name of the edge port. Defaults to None.
+        link_type (str, optional): The link type. Defaults to None.
+        guard (str, optional): The guard. Defaults to None.
+        bpdu_guard (str, optional): The bpdu guard. Defaults to None.
+        bpdu_filter (str, optional): The bpdu filter. Defaults to None.
+        portfast (str, optional): The portfast. Defaults to None.
+        uplink_fast (str, optional): The uplink fast. Defaults to None.
+        bpdu_guard_port_shutdown (str, optional): The bpdu guard port shutdown. Defaults to None.
+        cost (str, optional): The cost. Defaults to None.
+        port_priority (str, optional): The port priority. Defaults to None.
+        stp_enabled (str, optional): The STP enabled. Defaults to None.
+    Returns:
+        dict: A dictionary containing the STP port channel members.
+    Raises:
+        Exception: If there is an error while adding STP on the device.
+    """
+    path = get_stp_port_path(if_name)
+    req_data = {
+        "name": if_name,
+    }
+    if edge_port:
+        req_data["edge-port"] = str(edge_port)
+    if link_type:
+        req_data["link-type"] = str(link_type)
+    if guard:
+        req_data["guard"] = str(guard)
+    if bpdu_guard is not None:
+        req_data["bpdu-guard"] = bpdu_guard
+    if bpdu_filter is not None:
+        req_data["bpdu-filter"] = bpdu_filter
+    if portfast is not None:
+        req_data["openconfig-spanning-tree-ext:portfast"] = portfast
+    if uplink_fast is not None:
+        req_data["openconfig-spanning-tree-ext:uplink-fast"] = uplink_fast
+    if bpdu_guard_port_shutdown is not None:
+        req_data["openconfig-spanning-tree-ext:bpdu-guard-port-shutdown"] = bpdu_guard_port_shutdown
+    if cost:
+        req_data["openconfig-spanning-tree-ext:cost"] = cost
+    if port_priority:
+        req_data["openconfig-spanning-tree-ext:port-priority"] = port_priority
+    if stp_enabled is not None:
+        req_data["openconfig-spanning-tree-ext:spanning-tree-enable"] = stp_enabled
+
+    # deleting stp port config if exists before adding because subscribe does not support update.
+    # therefore deleting and adding again.
+    try:
+        delete_stp_port_member_from_device(device_ip=device_ip, if_name=if_name)
+    except Exception as e:
+        _logger.error(e)
+
+    # adding stp port config
+    return send_gnmi_set(
+        req=create_req_for_update(
+            [create_gnmi_update(path=path, val={
+                "openconfig-spanning-tree:interface": [
+                    {
+                        "name": if_name,
+                        "config": req_data
+                    }
+                ]
+            })]
+        ),
+        device_ip=device_ip
+    )
+
+
+def get_stp_port_members_from_device(device_ip: str, if_name: str = None):
+    """
+    Retrieves the STP port channel members from a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        if_name (str, optional): The name of the interface. Defaults to None.
+
+    Returns:
+        dict: A dictionary containing the STP port channel members.
+    """
+    path = get_stp_port_path(if_name)
+    return send_gnmi_get(path=[path], device_ip=device_ip)
+
+
+def delete_stp_port_member_from_device(device_ip: str, if_name: str = None):
+    """
+    Deletes the STP port channel members from a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        if_name (str, optional): The name of the interface. Defaults to None.
+
+    Returns:
+        dict: A dictionary containing the STP port channel members.
+    """
+    path = get_stp_port_path(if_name)
+    return send_gnmi_set(
+        get_gnmi_del_req(path=path), device_ip=device_ip
+    )

--- a/orca_nw_lib/stp_port_gnmi.py
+++ b/orca_nw_lib/stp_port_gnmi.py
@@ -28,28 +28,28 @@ def get_stp_port_path(if_name: str = None):
 
 
 def add_stp_port_members_on_device(
-        device_ip: str, if_name: str = None, edge_port: str = None, link_type: str = None, guard: str = None,
-        bpdu_guard: bool = None, bpdu_filter: bool = None, portfast: bool = None, uplink_fast: bool = None,
-        bpdu_guard_port_shutdown: bool = None, cost: int = None, port_priority: int = None,
-        stp_enabled: bool = None
+        device_ip: str, if_name: str, bpdu_guard: bool, uplink_fast: bool, stp_enabled: bool,
+        link_type: str = None, guard: str = None, edge_port: str = None, bpdu_filter: bool = None,
+        portfast: bool = None, bpdu_guard_port_shutdown: bool = None,
+        cost: int = None, port_priority: int = None,
 ):
     """
     Adds the STP port channel members on a device.
 
     Parameters:
-        device_ip (str): The IP address of the device.
-        if_name (str, optional): The name of the interface. Defaults to None.
-        edge_port (str, optional): The name of the edge port. Defaults to None.
-        link_type (str, optional): The link type. Defaults to None.
-        guard (str, optional): The guard. Defaults to None.
-        bpdu_guard (str, optional): The bpdu guard. Defaults to None.
-        bpdu_filter (str, optional): The bpdu filter. Defaults to None.
-        portfast (str, optional): The portfast. Defaults to None.
-        uplink_fast (str, optional): The uplink fast. Defaults to None.
-        bpdu_guard_port_shutdown (str, optional): The bpdu guard port shutdown. Defaults to None.
-        cost (str, optional): The cost. Defaults to None.
-        port_priority (str, optional): The port priority. Defaults to None.
-        stp_enabled (str, optional): The STP enabled. Defaults to None.
+        device_ip (str, Required): The IP address of the device.
+        if_name (str, Required): The name of the interface.
+        bpdu_guard (bool, Required): Enable/Disable BPDU guard. Valid Values: True, False.
+        uplink_fast (bool, Required): Enable/Disable uplink fast. Valid Values: True, False.
+        stp_enabled (bool, Required): Enable/Disable STP. Valid Values: True, False.
+        edge_port (str, Optional): The name of the edge port. Valid Values: EDGE_AUTO, EDGE_ENABLE, EDGE_DISABLE.
+        link_type (str, Optional): The type of the link. Valid Values: P2P, SHARED.
+        guard (str, Optional): The guard. Valid Values: NONE, ROOT, LOOP.
+        bpdu_filter (bool, Optional): Enable/Disable BPDU filter. Valid Values: True, False.
+        portfast (bool, Optional): Enable/Disable portfast. Valid Values: True, False.
+        bpdu_guard_port_shutdown (bool, Optional): Enable/Disable BPDU guard port shutdown. Valid Values: True, False.
+        cost (int, Optional): The cost. Valid Range: 1-200000000.
+        port_priority (int, Optional): The port priority. Valid Range: 0-240.
     Returns:
         dict: A dictionary containing the STP port channel members.
     Raises:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.26"
+version = "1.3.27"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.27"
+version = "1.3.28"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.25"
+version = "1.3.26"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"


### PR DESCRIPTION
Issues:

- STP Port Config - (orca_nw_lib) Payload and path are defined in SONiC Player Cell - "GET/SET/DELETE STP PORT"
config parameters received on get operation on the path should be updated during discovery in the vlan node already being created in DB. Wouldn't be bad to append stp_**** as prefix so that those parameters can be differentiated than other interface params.
- DB Updates (orca_nw_lib) - Interface specific path e.g. openconfig-spanning-tree:stp/interfaces/interface[name=Ethernet0]/config can be subscribed to receive notifications on any config change. Please note those subscriptions are interface specific which means subscription should be created for all interfaces for a device.
- orca_backend - REST end points to be updated.
- orca_backend - Respective Test cases covering CRUD operations on parameters.
- There should be an end-point resync (discover) STP global and port config not the complete device discovery, discovery function of STP from orca_nw_lib can be used for implementation.

Fixes: 
- created new files stp_port.py, stp_port_db.py, stp_port_gnmi.py.
- added new apis for crud operations in stp_port.
- added subscription both on delete and add.
- add new tests cases to test each parameter.
- added new stp_port db. Attched stp_port to device, portchannel, interface with gas relation.

Note: put api first delete gnmi config and then creates gnmi config. This is done to trigger subscription.