### PR TITLE
Update path for Port Channel configuration. #48

### DIFF
--- a/orca_nw_lib/port_chnl.py
+++ b/orca_nw_lib/port_chnl.py
@@ -311,7 +311,7 @@ def get_port_chnl_members(device_ip: str, port_chnl_name: str, ifname: str = Non
         ]
 
 
-def add_port_chnl_vlan_members(device_ip: str, chnl_name: str, if_mode: IFMode, vlan_ids: list[int] = None):
+def add_port_chnl_vlan_members(device_ip: str, chnl_name: str, if_mode: IFMode, vlan_ids: list[int]):
     """
     Adds VLAN members to a port channel on a device.
 
@@ -319,8 +319,7 @@ def add_port_chnl_vlan_members(device_ip: str, chnl_name: str, if_mode: IFMode, 
         device_ip (str): The IP address of the device.
         chnl_name (str): The name of the port channel.
         if_mode (IFMode): The interface mode of the port channel.
-        vlan_ids (list[int], optional): A list of VLAN IDs to be added to the port channel. Defaults to None.
-
+        vlan_ids (list[int]): A list of VLAN IDs to be added to the port channel. Defaults to None.
     Returns:
         None
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.26"
+version = "1.3.27"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.25"
+version = "1.3.26"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"


### PR DESCRIPTION
Issues:

- If we try to change the interface mode of a portchannel from "trunk" to "access", it is required to first delete trunk config from port channel, but from "access" to "trunk" restconf path doesn't require to delete "access" configuration. Test if it is the similar case with gNMI as well ? If so we can mitigate this in ORCA i.e. while making a port channel to be a "access" interface we first delete "trunk" config (only if there was any trunk config already.)
- Also while updating access vlan number on a portchannel which is already a in access mode, resconf requires to first delete the access config then apply new config with new vlan. Test if it is the similar case with gNMI? If so we also mitigate the 2 steps into one in ORCA i.e. If user requests to update access vlan number on a portchannel which is in interface mode "access" first delete the access config (only when there is already a access vlan assigned anf interface mode is "access") then apply new config.
-The API should take interface mode (enum) as an input and list of vlans, in case of access mode vlan list will have only one element .

Fixes:

- changes to for input to take if_mode and vland_ids.
- code changes to updates, access to trunk, tunk to access,  updating access valn with new vlan, updating tunk vlans.
- added new test cases to test switch between different access modes.
- modified exting test cases to use if_mode and vlan_ids as input.

Note: while switching deom tunk to access or updting access vlan. Existing vlans are removed beacuse inorder to update access vlan exting vlan must be deleted and upting from tunk to access trunk vlan needs to be deleted.
