### PR TITLE
STP Vlan Config. #59

### DIFF
--- a/orca_nw_lib/discovery.py
+++ b/orca_nw_lib/discovery.py
@@ -19,6 +19,7 @@ from .mclag import discover_mclag, discover_mclag_gw_macs
 
 from .port_chnl import discover_port_chnl
 from .stp import discover_stp
+from .stp_vlan import discover_stp_vlan
 from .vlan import discover_vlan
 from .utils import get_logging, get_networks, ping_ok
 
@@ -78,6 +79,13 @@ def discover_nw_features(device_ip: str):
         )
     try:
         discover_stp(device_ip)
+    except Exception as e:
+        report.append(
+            f"STP Discovery Failed on device {device_ip}, Reason: {e}"
+        )
+
+    try:
+        discover_stp_vlan(device_ip)
     except Exception as e:
         report.append(
             f"STP Discovery Failed on device {device_ip}, Reason: {e}"

--- a/orca_nw_lib/graph_db_models.py
+++ b/orca_nw_lib/graph_db_models.py
@@ -33,6 +33,7 @@ class Device(StructuredNode):
     mclag_gw_macs = RelationshipTo("MCLAG_GW_MAC", "HAS")
     bgp_global_af = RelationshipTo("BGP_GLOBAL_AF", "BGP_GLOBAL_AF")
     stp_global = RelationshipTo("STP_GLOBAL", "HAS")
+    stp_vlan = RelationshipTo("STP_VLAN", "HAS")
 
     def copy_properties(self, other):
         """
@@ -315,6 +316,8 @@ class Vlan(StructuredNode):
     memberInterfaces = RelationshipTo("Interface", "MEMBER_IF", model=VlanMemRel)
     memberPortChannel = RelationshipTo("PortChannel", "MEMBER_PORT_CHANNEL", model=VlanMemRel)
 
+    stp_vlan = RelationshipTo("STP_VLAN", "HAS")
+
     def __eq__(self, other):
         if isinstance(other, self.__class__):
             return self.vlanid == other.vlanid
@@ -354,3 +357,26 @@ class STP_GLOBAL(StructuredNode):
 
     def __str__(self):
         return str(self.device_ip)
+
+
+class STP_VLAN(StructuredNode):
+    """
+    Represents STP VLAN in the database.
+    """
+
+    vlan_id = IntegerProperty()
+    max_age = IntegerProperty()
+    hello_time = IntegerProperty()
+    forwarding_delay = IntegerProperty()
+    bridge_priority = IntegerProperty()
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.vlan_id == other.vlan_id
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.vlan_id)
+
+    def __str__(self):
+        return str(self.vlan_id)

--- a/orca_nw_lib/stp_vlan.py
+++ b/orca_nw_lib/stp_vlan.py
@@ -1,0 +1,144 @@
+from orca_nw_lib.device_db import get_device_db_obj
+from orca_nw_lib.graph_db_models import STP_VLAN
+from orca_nw_lib.stp_vlan_db import insert_device_stp_vlan_in_db, get_stp_vlan_from_db
+
+from orca_nw_lib.stp_vlan_gnmi import config_stp_vlan_on_device, get_stp_vlan_from_device, delete_stp_vlan_from_device
+from orca_nw_lib.utils import get_logging
+
+_logger = get_logging().getLogger(__name__)
+
+
+def _create_stp_vlan_graph_object(device_ip: str):
+    """
+    Create STP graph object
+
+    Args:
+        device_ip (str): The IP address of the device
+    """
+    stp_vlan_config = get_stp_vlan_from_device(device_ip=device_ip)
+    stp_vlan_obj_list = {}
+    members = []
+    _logger.debug(f"Retrieved stp vlan info from device {device_ip} {stp_vlan_config}")
+    stp_config_details = stp_vlan_config.get("openconfig-spanning-tree-ext:vlans", [])
+    for i in stp_config_details or []:
+        stp_vlan_config = i.get("config", {})
+        vlan_id = stp_vlan_config.get("vlan-id", None)
+        if vlan_id:
+            stp_vlan_obj_list[
+                STP_VLAN(
+                    vlan_id=vlan_id,
+                    bridge_priority=stp_vlan_config.get("bridge-priority", None),
+                    forwarding_delay=stp_vlan_config.get("forwarding-delay", None),
+                    hello_time=stp_vlan_config.get("hello-time", None),
+                    max_age=stp_vlan_config.get("max-age", None),
+                )
+            ] = members
+    return stp_vlan_obj_list
+
+
+def discover_stp_vlan(device_ip: str):
+    """
+    Discover the STP VLAN configuration on a device or all devices.
+
+    Args:
+        device_ip (str): The IP address of the device.
+
+    Returns:
+        None
+
+    Raises:
+        Exception: If there is an error discovering STP VLAN configuration on a device.
+    """
+    _logger.info("STP VLAN Discovery Started.")
+    devices = [get_device_db_obj(device_ip)] if device_ip else get_device_db_obj()
+    for device in devices:
+        _logger.info(f"Discovering STP VLAN of device {device}.")
+        try:
+            insert_device_stp_vlan_in_db(
+                device, _create_stp_vlan_graph_object(device.mgt_ip)
+            )
+        except Exception as e:
+            _logger.error(
+                f"Couldn't discover STP VLAN on device {device_ip}, Reason: {e}"
+            )
+            import traceback
+            print(traceback.format_exc())
+            raise
+
+
+def config_stp_vlan(
+        device_ip: str, vlan_id: int, bridge_priority: int = None, forwarding_delay: int = None,
+        hello_time: int = None, max_age: int = None
+):
+    """
+    Configures the STP VLAN settings on a device.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        vlan_id (int): The VLAN ID to configure.
+        bridge_priority (int, optional): The bridge priority value. Defaults to None.
+        forwarding_delay (int, optional): The forwarding delay value. Defaults to None.
+        hello_time (int, optional): The hello time value. Defaults to None.
+        max_age (int, optional): The maximum age value. Defaults to None.
+
+    Raises:
+        Exception: If there is an error while configuring STP VLAN on the device.
+
+    """
+    try:
+        config_stp_vlan_on_device(
+            device_ip=device_ip,
+            vlan_id=vlan_id,
+            bridge_priority=bridge_priority,
+            forwarding_delay=forwarding_delay,
+            hello_time=hello_time,
+            max_age=max_age
+        )
+    except Exception as e:
+        _logger.error(f"Failed to configure STP VLAN on device {device_ip}, Reason: {e}")
+        raise
+    finally:
+        discover_stp_vlan(device_ip=device_ip)
+
+
+def get_stp_vlan(device_ip: str, vlan_id: int = None):
+    """
+    Retrieves the STP VLAN configuration from the database based on the provided device IP and VLAN ID.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        vlan_id (int, optional): The VLAN ID to retrieve the configuration for.
+        If not provided, retrieves all VLAN configurations.
+
+    Returns:
+        list or dict: A list of STP VLAN objects if `vlan_id` is not provided,
+        or a single STP VLAN object if `vlan_id` is provided.
+    """
+    stp_vlan = get_stp_vlan_from_db(device_ip=device_ip, vlan_id=vlan_id)
+    if isinstance(stp_vlan, list):
+        return [i.__properties__ for i in stp_vlan]
+    else:
+        return stp_vlan.__properties__ if stp_vlan else None
+
+
+def delete_stp_vlan(device_ip: str, vlan_id: int = None):
+    """
+    Deletes STP VLAN configuration from a device.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        vlan_id (int, optional): The VLAN ID to delete the configuration for.
+
+    Raises:
+        Exception: If there is an error while deleting STP VLAN on the device.
+
+    Returns:
+        None
+    """
+    try:
+        delete_stp_vlan_from_device(device_ip=device_ip, vlan_id=vlan_id)
+    except Exception as e:
+        _logger.error(f"Failed to delete STP VLAN on device {device_ip}, Reason: {e}")
+        raise
+    finally:
+        discover_stp_vlan(device_ip=device_ip)

--- a/orca_nw_lib/stp_vlan_db.py
+++ b/orca_nw_lib/stp_vlan_db.py
@@ -1,0 +1,97 @@
+from orca_nw_lib.device_db import get_device_db_obj
+
+from orca_nw_lib.utils import get_logging
+
+from orca_nw_lib.graph_db_models import Device, STP_VLAN
+from orca_nw_lib.vlan_db import get_vlan_obj_from_db_using_id
+
+_logger = get_logging().getLogger(__name__)
+
+
+def copy_stp_vlan_obj(target_obj: STP_VLAN, src_obj: STP_VLAN):
+    """
+    Copy the properties of a source STP_VLAN object to a target STP_VLAN object.
+
+    Args:
+        target_obj (STP_VLAN): The target STP_VLAN object to copy the properties to.
+        src_obj (STP_VLAN): The source STP_VLAN object to copy the properties from.
+
+    Returns:
+        None
+    """
+    target_obj.vlan_id = src_obj.vlan_id
+    target_obj.bridge_priority = src_obj.bridge_priority
+    target_obj.forwarding_delay = src_obj.forwarding_delay
+    target_obj.hello_time = src_obj.hello_time
+    target_obj.max_age = src_obj.max_age
+
+
+def insert_device_stp_vlan_in_db(device: Device, stp_vlan_obj: dict):
+    """
+    Inserts the given STP VLAN object into the database for the specified device.
+
+    Args:
+        device (Device): The device object representing the device to insert the STP VLAN into.
+        stp_vlan_obj (dict): A dictionary containing the STP VLAN object to insert, mapped to its members.
+
+    Returns:
+        None
+    """
+    _logger.info(f"Inserting STP Vlan on device {device.mgt_ip}.")
+    for stp_vlan, members in stp_vlan_obj.items():
+        if existing_stp_valn := get_stp_vlan_from_db(device.mgt_ip, stp_vlan.vlan_id):
+            # updating stp vlan node in db
+            copy_stp_vlan_obj(existing_stp_valn, stp_vlan)
+            existing_stp_valn.save()
+            new_vlan_obj = existing_stp_valn
+        else:
+            # inserting stp vlan node in db
+            stp_vlan.save()
+            new_vlan_obj = stp_vlan
+
+        device.stp_vlan.connect(new_vlan_obj)
+
+        # adding stp vlan  node in db
+        vlan = get_vlan_obj_from_db_using_id(device.mgt_ip, stp_vlan.vlan_id)
+        if vlan:
+            vlan.stp_vlan.connect(new_vlan_obj)
+
+    # removing stp vlan if it exists on db and not on device.
+    stp_vlan_obj_from_db = get_stp_vlan_from_db(device.mgt_ip)
+    for existing_vlan_in_db in stp_vlan_obj_from_db:
+        if existing_vlan_in_db not in stp_vlan_obj:
+            delete_stp_vlan_from_db(device_ip=device.mgt_ip, vlan_id=existing_vlan_in_db.vlan_id)
+
+
+def get_stp_vlan_from_db(device_ip: str, vlan_id: int = None):
+    """
+    Retrieves the STP VLAN object from the database based on the device IP and VLAN ID.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        vlan_id (int, optional): The VLAN ID to retrieve. Defaults to None.
+
+    Returns:
+        STP_VLAN or None: The STP VLAN object if found, or None if not found.
+            If vlan_id is not provided, returns a list of all STP VLAN objects for the device.
+    """
+    device: Device = get_device_db_obj(device_ip)
+    if device:
+        return device.stp_vlan.get_or_none(vlan_id=vlan_id) if vlan_id else device.stp_vlan.all()
+
+
+def delete_stp_vlan_from_db(device_ip: str, vlan_id: int = None):
+    """
+    Deletes a STP VLAN object from the database based on the device IP and VLAN ID.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        vlan_id (int, optional): The VLAN ID to delete. Defaults to None.
+
+    Returns:
+        None
+    """
+    device: Device = get_device_db_obj(device_ip)
+    stp_vlan = device.stp_vlan.get_or_none(vlan_id=vlan_id) if device else None
+    if stp_vlan:
+        stp_vlan.delete()

--- a/orca_nw_lib/stp_vlan_gnmi.py
+++ b/orca_nw_lib/stp_vlan_gnmi.py
@@ -1,0 +1,107 @@
+from orca_nw_lib.gnmi_pb2 import Path
+
+from orca_nw_lib.gnmi_util import (send_gnmi_set,
+                                   get_gnmi_path,
+                                   create_gnmi_update,
+                                   create_req_for_update,
+                                   send_gnmi_get,
+                                   get_gnmi_del_req)
+
+
+def get_stp_vlan_path(vlan_id: int = None) -> Path:
+    """
+    Returns the path to the STP VLAN configuration.
+
+    Args:
+        vlan_id (int, optional): The VLAN ID. Defaults to None.
+    Returns:
+        Path: The path to the STP VLAN configuration.
+    """
+    if vlan_id:
+        get_gnmi_path(f"/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans[vlan_id={vlan_id}]")
+    return get_gnmi_path(f"/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans")
+
+
+def config_stp_vlan_on_device(
+        device_ip: str, vlan_id: int, bridge_priority: int = None, forwarding_delay: int = None,
+        hello_time: int = None, max_age: int = None
+):
+    """
+    Configures STP on a device.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        vlan_id (int): The VLAN ID.
+        bridge_priority (int, optional): The bridge priority. Defaults to None.
+        forwarding_delay (int, optional): The forwarding delay. Defaults to None.
+        hello_time (int, optional): The hello time. Defaults to None.
+        max_age (int, optional): The maximum age. Defaults to None.
+
+    Raises:
+        Exception: If there is an error while configuring STP on the device.
+
+    Returns:
+        The result of sending a GNMI set request to configure STP on the device.
+    """
+    config = {
+        "vlan-id": vlan_id,
+    }
+    if bridge_priority:
+        config["bridge-priority"] = bridge_priority
+    if forwarding_delay:
+        config["forwarding-delay"] = forwarding_delay
+    if hello_time:
+        config["hello-time"] = hello_time
+    if max_age:
+        config["max-age"] = max_age
+    request = create_gnmi_update(
+        path=get_stp_vlan_path(),
+        val={
+            "openconfig-spanning-tree-ext:vlans": [
+                {
+                    "vlan-id": vlan_id,
+                    "config": config
+                }
+            ]
+        }
+    )
+    return send_gnmi_set(create_req_for_update([request]), device_ip)
+
+
+def get_stp_vlan_from_device(device_ip: str, vlan_id: int = None):
+    """
+    Gets STP VLAN configuration from a device.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        vlan_id (int): The VLAN ID.
+
+    Returns:
+        The result of sending a GNMI get request to get STP VLAN configuration from the device.
+    """
+    try:
+        return send_gnmi_get(
+            device_ip=device_ip,
+            path=[get_stp_vlan_path(vlan_id=vlan_id)],
+        )
+    except Exception:
+        return {}
+
+
+def delete_stp_vlan_from_device(device_ip: str, vlan_id: int):
+    """
+    Deletes STP VLAN configuration from a device.
+
+    Args:
+        device_ip (str): The IP address of the device.
+        vlan_id (int): The VLAN ID.
+
+    Returns:
+        The result of sending a GNMI set request to delete STP VLAN configuration from the device.
+    """
+    return send_gnmi_set(
+        device_ip=device_ip,
+        req=get_gnmi_del_req(
+            path=get_stp_vlan_path()
+        )
+    )

--- a/orca_nw_lib/vlan.py
+++ b/orca_nw_lib/vlan.py
@@ -3,6 +3,7 @@ from orca_nw_lib.vlan_gnmi import get_vlan_details_from_device
 from .common import IFMode, VlanAutoState
 
 from .device_db import get_device_db_obj
+from .stp_vlan import discover_stp_vlan
 from .vlan_db import (
     get_vlan_member_port_channels_from_db,
     get_vlan_obj_from_db,
@@ -139,6 +140,7 @@ def del_vlan(device_ip, vlan_name: str):
         raise
     finally:
         discover_vlan(device_ip)
+        discover_stp_vlan(device_ip)
 
 
 def remove_ip_from_vlan(device_ip: str, vlan_name: str):

--- a/orca_nw_lib/vlan_db.py
+++ b/orca_nw_lib/vlan_db.py
@@ -158,3 +158,22 @@ def insert_vlan_in_db(device: Device, vlans_obj_vs_mem):
     for vlan_in_db in get_vlan_obj_from_db(device.mgt_ip) or []:
         if vlan_in_db not in vlans_obj_vs_mem:
             del_vlan_from_db(device.mgt_ip, vlan_in_db.name)
+
+
+def get_vlan_obj_from_db_using_id(device_ip, vlan_id: int = None):
+    """
+    Get the VLAN object from the database.
+
+    Parameters:
+        device_ip (str): The IP address of the device.
+        vlan_id (int, optional): The ID of the VLAN. Defaults to None.
+
+    Returns:
+        The VLAN object from the database if `vlan_name` is None, otherwise the VLAN object with the specified name.
+    """
+    device: Device = get_device_db_obj(device_ip)
+    return (
+        (device.vlans.all()
+        if not vlan_id
+        else device.vlans.get_or_none(vlanid=vlan_id)) if device else None
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.26"
+version = "1.3.27"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "1.3.27"
+version = "1.3.29"
 name = "orca_nw_lib"
 description = "APIs to interact with SONiC NW"
 readme = "README.md"


### PR DESCRIPTION
Issuess:

- STP VLAN Config - (orca_nw_lib) Payload and path are defined in SONiC Player Cell - "GET/SET/DELETE STP PVST VLAN"
config parameters received on get operation on the path should be updated during discovery in the vlan node already being created in DB. Wouldn't be bad to append stp_**** as prefix so that those parameters can be differentiated than other vlan params.
- DB Updates (orca_nw_lib) - Vlan specific path e.g. /openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans[vlan-id=6]/config can be subscribed to receive notifications on anyconfig change. Please note those subscriptions are vylan specific which means subscription should be created for already exiting vlans or newly created vlans and should be removed for vlan which are deleted.
- orca_backend - REST end points to be updated.
- orca_backend - Respective Test cases covering CRUD operations on parameters.

Fixes: 
- created new files stp_vlan.py, stp_vlan_db.py, stp_vlan_gnmi.py.
- added new apis for crud operations in stp_vlan.
- add new tests cases to test each parameter.
- added new stp_vlan db. Attched stp_vlan to device, vlan with has relation.